### PR TITLE
docs: add AGPL extension exception for third-party plugins

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -22,7 +22,8 @@ permission to create extensions ("plugins") that interact with gnubok
 solely through the documented Extension API — defined in
 lib/extensions/types.ts (the Extension interface, ExtensionContext,
 and related types), lib/events/types.ts (the event bus), and the
-extension catch-all API route — without those extensions being
+extension catch-all API route (app/api/extensions/ext/[...path]/route.ts)
+— without those extensions being
 considered derivative works of gnubok under the terms of this License.
 
 This means you may license your extensions under any terms you choose,
@@ -41,8 +42,11 @@ If you modify gnubok itself — including its core libraries, database
 migrations, API routes, or UI components — the modified version remains
 subject to the full terms of the GNU Affero General Public License.
 
-This exception is irrevocable. It applies to all past and future
-versions of gnubok released under this license by the copyright holder.
+The copyright holder will not revoke this exception in any future
+release of gnubok. Note that under AGPL version 3 section 7, any party
+who redistributes gnubok may remove additional permissions from their
+copy; however, the original grant from the copyright holder remains
+in effect for copies obtained directly or indirectly from this source.
 
 ----------------------------------------------------------------------
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 If you discover a security vulnerability in gnubok, please report it responsibly. **Do not open a public issue.**
 
-Email: **jakob.wennberg@arcim.io**
+Email: **security@arcim.io**
 
 Include:
 - Description of the vulnerability


### PR DESCRIPTION
Extensions that interact solely through the documented Extension API (Extension interface, ExtensionContext, event bus) are not considered derivative works and may be licensed under any terms, including proprietary. Core modifications remain fully AGPL-3.0.