### PR TITLE
fix: skip BTRANS/RTRANS in SIE parser to prevent false balance errors

### DIFF
--- a/lib/import/sie-parser.ts
+++ b/lib/import/sie-parser.ts
@@ -574,13 +574,21 @@ export function parseSIEFile(content: string): ParsedSIEFile {
         case 'TRANS':
         case 'RTRANS':
         case 'BTRANS': {
-          // #TRANS/#RTRANS/#BTRANS accountNumber {objectList} amount [date] [description] [quantity] [signature]
-          // BTRANS = Added/corrected transaction lines (part of the voucher)
-          // RTRANS = Removed/reversed transaction lines (amounts already have correct sign)
-          // All three must be included for vouchers to balance correctly.
-          // Fortnox/Bokio/Visma only emit #TRANS — this is a no-op for those providers.
+          // #TRANS = final transaction lines (the current state of the voucher)
+          // #RTRANS = removed lines (correction audit trail — original lines that were undone)
+          // #BTRANS = added lines (correction audit trail — new lines that replaced removed ones)
+          //
+          // When a voucher has been corrected, Fortnox/Visma emit all three types.
+          // Only #TRANS represents the final voucher state; #RTRANS and #BTRANS are
+          // supplementary history. We skip RTRANS/BTRANS to avoid double-counting
+          // which would make balanced vouchers appear unbalanced.
           if (!currentVoucher) {
             addIssue(issues, 'error', lineNum, `${tag} outside of VER block`, tag)
+            break
+          }
+
+          // Skip RTRANS/BTRANS — they are correction audit trail, not final state
+          if (tag === 'RTRANS' || tag === 'BTRANS') {
             break
           }
 


### PR DESCRIPTION
## Summary
- SIE files from Fortnox contain `#BTRANS` (added) and `#RTRANS` (removed) correction audit trail lines alongside `#TRANS` (final state) lines
- The parser was summing all three types, causing corrected vouchers to appear unbalanced (e.g. A23 showing diff: -200,000 when it actually balances to 0)
- Now skips `#BTRANS`/`#RTRANS` since `#TRANS` alone represents the final voucher state
- Tested against a real Fortnox SIE4 export with 2,107 vouchers — all pass validation

## Test plan
- [x] All 57 existing SIE parser tests pass
- [x] Verified against real Fortnox export (`NearbyStoreSverigeAB20251204_145733.se`) — 0 errors, down from 62

🤖 Generated with [Claude Code](https://claude.com/claude-code)