### PR TITLE
fix: exclude .well-known from auth middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -15,6 +15,6 @@ export const config = {
      * - api (API routes - they handle their own auth)
      * - Static assets (images, scripts, manifest, icons, etc.)
      */
-    '/((?!_next/static|_next/image|favicon.ico|api|sw\\.js|sw-register\\.js|manifest\\.json|icons/|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|js|json)$).*)',
+    '/((?!_next/static|_next/image|favicon.ico|api|\\.well-known|sw\\.js|sw-register\\.js|manifest\\.json|icons/|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|js|json)$).*)',
   ],
 }


### PR DESCRIPTION
## Summary

Root cause of MCP connector not working in Claude Desktop: the `.well-known/oauth-protected-resource` and `.well-known/oauth-authorization-server` endpoints were being intercepted by the auth middleware and redirected to `/login`. Claude Desktop could never discover the OAuth endpoints.

One-character fix: add `\.well-known` to the middleware matcher exclusion list.

## Test plan

- [ ] `curl https://app.gnubok.se/.well-known/oauth-protected-resource` returns JSON (not redirect)
- [ ] Claude Desktop connector shows tools after connecting

🤖 Generated with [Claude Code](https://claude.com/claude-code)