### PR TITLE
feat: gnubok-mcp npm package for Claude Desktop

### DIFF
--- a/components/settings/ApiKeysPanel.tsx
+++ b/components/settings/ApiKeysPanel.tsx
@@ -206,7 +206,7 @@ export function ApiKeysPanel() {
             <p className="text-xs text-muted-foreground mb-2">
               Lägg till i <code className="text-xs">claude_desktop_config.json</code> (Inställningar &rarr; Developer):
             </p>
-            <pre className="rounded-md bg-muted p-4 text-xs font-mono overflow-x-auto">
+            <pre className="rounded-md bg-muted p-4 text-xs font-mono overflow-x-auto select-all">
 {`{
   "mcpServers": {
     "gnubok": {

--- a/packages/gnubok-mcp/index.mjs
+++ b/packages/gnubok-mcp/index.mjs
@@ -19,7 +19,7 @@
  */
 
 const API_KEY = process.env.GNUBOK_API_KEY
-const URL = process.env.GNUBOK_URL || 'https://app.gnubok.se/api/extensions/ext/mcp-server/mcp'
+const MCP_URL = process.env.GNUBOK_URL || 'https://app.gnubok.se/api/extensions/ext/mcp-server/mcp'
 
 if (!API_KEY) {
   process.stderr.write(
@@ -77,7 +77,7 @@ async function handleMessage(line) {
   const isNotification = parsed.id === undefined || parsed.id === null
 
   try {
-    const res = await fetch(URL, {
+    const res = await fetch(MCP_URL, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -91,6 +91,23 @@ async function handleMessage(line) {
     }
 
     const text = await res.text()
+
+    // Guard against non-JSON error responses (CDN HTML pages, proxy errors)
+    if (!res.ok && !isNotification) {
+      let message = `HTTP ${res.status}`
+      try {
+        const json = JSON.parse(text)
+        if (json.error) message = typeof json.error === 'string' ? json.error : JSON.stringify(json.error)
+      } catch { /* body wasn't JSON — use generic message */ }
+      const errorResponse = JSON.stringify({
+        jsonrpc: '2.0',
+        id: parsed.id,
+        error: { code: -32000, message },
+      })
+      process.stdout.write(errorResponse + '\n')
+      return
+    }
+
     if (text) {
       process.stdout.write(text + '\n')
     }

--- a/packages/gnubok-mcp/package.json
+++ b/packages/gnubok-mcp/package.json
@@ -1,13 +1,19 @@
 {
   "name": "gnubok-mcp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Connect Claude Desktop to your gnubok bookkeeping account",
   "bin": {
     "gnubok-mcp": "./index.mjs"
   },
   "type": "module",
   "license": "MIT",
-  "keywords": ["mcp", "gnubok", "bookkeeping", "claude", "accounting"],
+  "keywords": [
+    "mcp",
+    "gnubok",
+    "bookkeeping",
+    "claude",
+    "accounting"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/erp-mafia/gnubok"
@@ -15,5 +21,7 @@
   "engines": {
     "node": ">=18"
   },
-  "files": ["index.mjs"]
+  "files": [
+    "index.mjs"
+  ]
 }


### PR DESCRIPTION
## Summary

Published `gnubok-mcp@1.0.0` to npm. Lets any user connect Claude Desktop to their gnubok account:

```json
{
  "mcpServers": {
    "gnubok": {
      "command": "npx",
      "args": ["gnubok-mcp"],
      "env": {
        "GNUBOK_API_KEY": "gnubok_sk_..."
      }
    }
  }
}
```

Zero dependencies, 1.3 KB. Works as a stdio-to-HTTP bridge while Claude Desktop's OAuth connector is in beta (#78 filed).

Also updates the Settings > API panel instructions to show the npx approach.

## Test plan

- [x] `npm publish` succeeded
- [ ] `npx gnubok-mcp` works in Claude Desktop config
- [ ] Settings panel shows correct instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)