### PR TITLE
feat: MCP Apps receipt matcher widget

### DIFF
--- a/extensions/general/mcp-server/__tests__/receipt-matcher.test.ts
+++ b/extensions/general/mcp-server/__tests__/receipt-matcher.test.ts
@@ -99,7 +99,6 @@ async function parseResult(response: Response) {
 describe('MCP Receipt Matcher', () => {
   let supabase: ReturnType<typeof createQueuedMockSupabase>['supabase']
   let enqueueMany: ReturnType<typeof createQueuedMockSupabase>['enqueueMany']
-  let reset: ReturnType<typeof createQueuedMockSupabase>['reset']
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -107,7 +106,6 @@ describe('MCP Receipt Matcher', () => {
     const mock = createQueuedMockSupabase()
     supabase = mock.supabase
     enqueueMany = mock.enqueueMany
-    reset = mock.reset
     vi.mocked(createServiceClientNoCookies).mockReturnValue(supabase as never)
   })
 

--- a/extensions/general/mcp-server/server.ts
+++ b/extensions/general/mcp-server/server.ts
@@ -507,7 +507,7 @@ const tools: McpTool[] = [
         try {
           const doc = await uploadDocument(supabase, userId, {
             name: filename,
-            buffer: buffer.buffer as ArrayBuffer,
+            buffer: buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength) as ArrayBuffer,
             type: mimeType,
           }, {
             upload_source: 'api' as DocumentUploadSource,

--- a/extensions/general/mcp-server/widget-html.ts
+++ b/extensions/general/mcp-server/widget-html.ts
@@ -202,7 +202,7 @@ export const RECEIPT_MATCHER_HTML = `<!DOCTYPE html>
       const formatted = amt.toLocaleString('sv-SE', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) + ' kr';
 
       html += '<tr class="' + cls + '" data-idx="' + i + '">';
-      html += '<td>' + (tx.date || '') + '</td>';
+      html += '<td>' + esc(tx.date || '') + '</td>';
       html += '<td>' + esc(tx.description || tx.merchant_name || '') + '</td>';
       html += '<td class="amount ' + amtClass + '">' + formatted + '</td>';
 
@@ -301,7 +301,7 @@ export const RECEIPT_MATCHER_HTML = `<!DOCTYPE html>
         resizeImage(reader.result, function(dataUri) {
           transactions[idx]._file = file.name;
           transactions[idx]._dataUri = dataUri;
-          transactions[idx]._mimeType = file.type;
+          transactions[idx]._mimeType = 'image/jpeg';
           render();
           bookTransaction(idx);
         });


### PR DESCRIPTION
## Summary
- Adds an interactive receipt matcher widget that renders inline in Claude Desktop via MCP Apps (SEP-1865)
- Users drag receipts onto uncategorized transactions to categorize, book, and attach documents in one flow — without leaving the conversation
- Extracts `categorizeTransactionCore()` shared between `gnubok_categorize_transaction` and the new `gnubok_categorize_with_receipt` tool
- Adds `resources/list` and `resources/read` MCP protocol handlers for the widget HTML
- Self-contained ~280-line HTML widget with MCP Apps bridge, drag-and-drop, client-side image resize (max 1600px)

## New MCP tools
- `gnubok_receipt_matcher` — read-only, returns uncategorized transactions + renders widget via `_meta.ui.resourceUri`
- `gnubok_categorize_with_receipt` — categorizes transaction + decodes data URI + uploads receipt via `uploadDocument()`

## Test plan
- [x] 16 new unit tests covering protocol additions, both tools, refactored original tool, and structuredContent behavior
- [x] Full test suite passes (1753 tests)
- [x] Production build succeeds with no type errors
- [ ] Manual test with MCP Apps basic-host (ext-apps repo)
- [ ] Claude Desktop end-to-end test with `npx gnubok-mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)