### PR TITLE
fix: make company detail grids responsive (GNU-8)

### DIFF
--- a/app/(dashboard)/settings/page.tsx
+++ b/app/(dashboard)/settings/page.tsx
@@ -353,7 +353,7 @@ export default function SettingsPage() {
                 </CardDescription>
               </CardHeader>
               <CardContent className="space-y-4">
-                <div className="grid grid-cols-2 gap-4">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                   <div className="space-y-2">
                     <Label htmlFor="company_name">Företagsnamn</Label>
                     <Input
@@ -389,7 +389,7 @@ export default function SettingsPage() {
                   />
                 </div>
 
-                <div className="grid grid-cols-2 gap-4">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                   <div className="space-y-2">
                     <Label htmlFor="postal_code">Postnummer</Label>
                     <Input


### PR DESCRIPTION
## Summary
- Made company name/org number and postal code/city grids stack on mobile (`grid-cols-1 sm:grid-cols-2`)
- Two class changes in `app/(dashboard)/settings/page.tsx` at lines 356 and 392

## Linear
Closes GNU-8

## Code Review
🟢 **Ready to merge** — minimal CSS-only change, no logic affected.

## Test plan
- [ ] View settings page on mobile viewport (<640px) — fields should stack vertically
- [ ] View settings page on desktop viewport (≥640px) — fields should display side-by-side

🤖 Generated with [Claude Code](https://claude.com/claude-code)