### PR TITLE
fix: make bank & invoice grids responsive on settings page (GNU-7)

### DIFF
--- a/app/(dashboard)/settings/page.tsx
+++ b/app/(dashboard)/settings/page.tsx
@@ -419,7 +419,7 @@ export default function SettingsPage() {
                 </CardDescription>
               </CardHeader>
               <CardContent className="space-y-4">
-                <div className="grid grid-cols-3 gap-4">
+                <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
                   <div className="space-y-2">
                     <Label>Bank</Label>
                     <BankNameCombobox
@@ -523,7 +523,7 @@ export default function SettingsPage() {
                 </CardDescription>
               </CardHeader>
               <CardContent className="space-y-4">
-                <div className="grid grid-cols-3 gap-4 items-end">
+                <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 items-end">
                   <div className="space-y-2">
                     <Label htmlFor="invoice_prefix">Fakturaprefix</Label>
                     <Input


### PR DESCRIPTION
## Summary
- Bank details grid (Bank/Clearing/Kontonummer) and invoice settings grid (Prefix/Nummer/Dagar) now stack to single column on mobile, 3 columns on `sm:` and up
- Same pattern as GNU-8 fix (c149822) for company detail grids

## Linear
Closes GNU-7

## Code Review
🟢 **Ready to merge** — minimal CSS-only change, consistent with existing pattern

## Test plan
- [ ] Verify bank details fields stack vertically on mobile viewport
- [ ] Verify invoice settings fields stack vertically on mobile viewport
- [ ] Verify both grids show 3 columns on sm: breakpoint and above

🤖 Generated with [Claude Code](https://claude.com/claude-code)