### PR TITLE
fix: improve date filter UX with partial dates and Apply button (GNU-18)

### DIFF
--- a/components/bookkeeping/JournalEntryList.tsx
+++ b/components/bookkeeping/JournalEntryList.tsx
@@ -44,7 +44,46 @@ export default function JournalEntryList({ periodId }: Props) {
   const [dateToInput, setDateToInput] = useState('')
   const pageSize = 20
 
-  const isValidDate = (v: string) => /^\d{4}-\d{2}-\d{2}$/.test(v) && !isNaN(Date.parse(v))
+  const normalizeDate = (v: string): string | null => {
+    const trimmed = v.trim()
+    if (!trimmed) return null
+    // YYYY
+    if (/^\d{4}$/.test(trimmed)) {
+      const y = parseInt(trimmed, 10)
+      if (y < 1900 || y > 2100) return null
+      return `${trimmed}-01-01`
+    }
+    // YYYY-MM
+    if (/^\d{4}-\d{2}$/.test(trimmed)) {
+      const [y, m] = trimmed.split('-').map(Number)
+      if (y < 1900 || y > 2100 || m < 1 || m > 12) return null
+      return `${trimmed}-01`
+    }
+    // YYYY-MM-DD
+    if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+      const d = new Date(trimmed + 'T00:00:00')
+      if (isNaN(d.getTime())) return null
+      // Verify the date didn't roll over (e.g. 2024-02-31 → March)
+      const [y, m, day] = trimmed.split('-').map(Number)
+      if (d.getFullYear() !== y || d.getMonth() + 1 !== m || d.getDate() !== day) return null
+      return trimmed
+    }
+    return null
+  }
+
+  const applyDateFilter = () => {
+    const fromVal = dateFromInput.trim()
+    const toVal = dateToInput.trim()
+    const nextFrom = fromVal === '' ? '' : normalizeDate(fromVal) ?? dateFrom
+    const nextTo = toVal === '' ? '' : normalizeDate(toVal) ?? dateTo
+    setDateFromInput(nextFrom)
+    setDateToInput(nextTo)
+    if (nextFrom !== dateFrom || nextTo !== dateTo) {
+      setDateFrom(nextFrom)
+      setDateTo(nextTo)
+      setPage(0)
+    }
+  }
 
   const fetchAttachmentCounts = useCallback(async (entryIds: string[]) => {
     if (entryIds.length === 0) return
@@ -174,12 +213,15 @@ export default function JournalEntryList({ periodId }: Props) {
             onChange={(e) => setDateFromInput(e.target.value)}
             onBlur={() => {
               const v = dateFromInput.trim()
-              const next = v === '' ? '' : isValidDate(v) ? v : dateFrom
-              setDateFromInput(next)
-              if (next !== dateFrom) { setDateFrom(next); setPage(0) }
+              if (v === '') return
+              const normalized = normalizeDate(v)
+              if (normalized) setDateFromInput(normalized)
             }}
             onKeyDown={(e) => {
-              if (e.key === 'Enter') (e.target as HTMLInputElement).blur()
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                applyDateFilter()
+              }
             }}
             className="h-8 w-[145px] text-xs"
           />
@@ -190,15 +232,26 @@ export default function JournalEntryList({ periodId }: Props) {
             onChange={(e) => setDateToInput(e.target.value)}
             onBlur={() => {
               const v = dateToInput.trim()
-              const next = v === '' ? '' : isValidDate(v) ? v : dateTo
-              setDateToInput(next)
-              if (next !== dateTo) { setDateTo(next); setPage(0) }
+              if (v === '') return
+              const normalized = normalizeDate(v)
+              if (normalized) setDateToInput(normalized)
             }}
             onKeyDown={(e) => {
-              if (e.key === 'Enter') (e.target as HTMLInputElement).blur()
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                applyDateFilter()
+              }
             }}
             className="h-8 w-[145px] text-xs"
           />
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-8 text-xs"
+            onClick={applyDateFilter}
+          >
+            Filtrera
+          </Button>
           {(dateFrom || dateTo) && (
             <button
               type="button"


### PR DESCRIPTION
## Summary
- Replace strict `YYYY-MM-DD` validation with `normalizeDate` that accepts partial dates (`2024` → `2024-01-01`, `2024-10` → `2024-10-01`)
- Change blur behavior to normalize input without clearing — filter only applies via "Filtrera" button or Enter key
- Add explicit "Filtrera" button next to date inputs

## Linear
Closes GNU-18

## Code Review
🟢 **Ready to merge** — no security issues, no bugs found. `normalizeDate` includes date rollover protection (e.g. rejects Feb 31). Blur→click race condition analyzed and confirmed safe.

## Test plan
- [x] Type `2024` in "Från" field, blur → input shows `2024-01-01`, filter NOT applied yet
- [x] Click "Filtrera" → filter applies, entries filtered
- [x] Type `2024-10` in "Till" field, press Enter → normalizes to `2024-10-01` and applies
- [x] Type invalid date `abc`, blur → input keeps `abc`, Filtrera ignores it
- [x] Clear filter with X button → both inputs and filters reset
- [x] Type `2024-02-31`, blur → rejected (date rollover), input unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)