### PR TITLE
fix: always use business PSU type for bank connections

### DIFF
--- a/extensions/general/enable-banking/index.ts
+++ b/extensions/general/enable-banking/index.ts
@@ -92,7 +92,6 @@ export const enableBankingExtension: Extension = {
             user_id: user.id,
             bank: aspsp_name,
             country: aspsp_country,
-            entity_type: companySettings?.entity_type,
             psu_type: psuType,
           })
 


### PR DESCRIPTION
## Summary
- EF (sole trader) users connecting to Nordea got personal accounts instead of business accounts
- Root cause: `psu_type` was derived from `entity_type` — EF mapped to `'personal'`, only AB mapped to `'business'`
- Fix: always use `'business'` PSU type since gnubok is accounting software and users always want business accounts

## Test plan
- [ ] Connect EF company to Nordea — verify business accounts are returned
- [ ] Connect AB company to Nordea — verify still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)