### PR TITLE
fix: increase initial bank sync window from 90 to 120 days

### DIFF
--- a/app/(dashboard)/settings/banking/page.tsx
+++ b/app/(dashboard)/settings/banking/page.tsx
@@ -34,7 +34,7 @@ export default function BankingSettingsPage() {
         fetch('/api/extensions/ext/enable-banking/sync', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ connection_id: connectionId, days_back: 90 }),
+          body: JSON.stringify({ connection_id: connectionId, days_back: 120 }),
         })
           .then(res => res.json())
           .then(data => {


### PR DESCRIPTION
## Summary
- Initial bank sync only fetched 90 days of transactions, missing late December data for users connecting in April
- Increased to 120 days to cover a full quarter plus buffer

## Test plan
- [ ] Connect bank account — verify transactions are fetched from ~120 days back

🤖 Generated with [Claude Code](https://claude.com/claude-code)