### PR TITLE
feat: add Swedish payroll & VAT skills, init support contact route

### DIFF
--- a/.claude/skills/swedish-payroll/SKILL.md
+++ b/.claude/skills/swedish-payroll/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: swedish-payroll
+description: Swedish payroll (lön & arbetsgivaravgifter) compliance reference for developers building payroll or accounting software. Covers arbetsgivardeklaration (AGI) filing, sociala avgifter (31.42% breakdown and age reductions), skatteavdrag (tax table lookup, column system, jämkning), förmånsbeskattning (bilförmån calculation, kostförmån, friskvård, KPO), semesterlöneskuld (procentregeln 12%, sammalöneregeln, BAS 2920/7090), OB-tillägg and övertid (Arbetstidslagen limits, CBA divisors), traktamente (domestic/international rates, tremånadersregeln, meal reductions), utlägg vs kostnadsersättning (milersättning, körjournal), F-skatt vs A-skatt distinction and verification, BAS 7xxx series account mapping (7010-7699 wages, 7510 avgifter, 7321-7332 traktamente/resor), nettolöneavdrag vs bruttolöneavdrag processing order, löneväxling (1.058 factor, pension cap), and sjuklön (karensavdrag, day 2-14 at 80%, Försäkringskassan day 15+). Trigger on any mention of lön, lönehantering, payroll, arbetsgivardeklaration, AGI, arbetsgivaravgifter, skatteavdrag, skattetabell, förmånsbeskattning, bilförmån, kostförmån, friskvårdsbidrag, semesterlön, semesterlöneskuld, OB-tillägg, övertidsersättning, traktamente, milersättning, utlägg, F-skatt, A-skatt, FA-skatt, sjuklön, karensavdrag, löneväxling, bruttolöneavdrag, nettolöneavdrag, BAS 7xxx accounts, or any Swedish payroll compliance question. Also trigger when the user asks how to book salary, employer contributions, vacation pay, or sick pay in a Swedish context, or when implementing payroll calculations, AGI XML generation, or tax table lookups. This skill is a developer compliance oracle, not an end-user payroll guide.
+---
+
+# Swedish Payroll Compliance
+
+Developer-facing compliance reference for building Swedish payroll software. This skill answers questions about statutory rates, filing obligations, benefit valuations, BAS account mappings, and calculation logic so you can verify your implementation is correct.
+
+## How to use this skill
+
+This skill has a router structure. The SKILL.md contains the most critical rules and rates you need constantly. Detailed reference material lives in `references/`. Read the relevant reference file when you need depth on a specific area.
+
+### Reference files
+
+| File | When to read |
+|---|---|
+| `references/agi-filing.md` | Questions about arbetsgivardeklaration (AGI), XML schema, field codes (fältkoder), filing deadlines, corrections, penalties, Skatteverket API submission |
+| `references/social-charges.md` | Questions about arbetsgivaravgifter component breakdown, age-based reductions, egenavgifter, växa-stöd, forskningsavdrag, youth discount, thresholds (PBB/IBB/SGI) |
+| `references/tax-tables.md` | Questions about skatteavdrag, skattetabeller, column system, jämkning, sidoinkomst, statlig inkomstskatt brytpunkt, Skatteverket tax table data format |
+| `references/benefits.md` | Questions about förmånsbeskattning: bilförmån (all 3 formula generations, miljöbil reductions), kostförmån, friskvård, KPO, telefon/internet, bostadsförmån |
+| `references/vacation-pay.md` | Questions about semesterlön, semesterlöneskuld, procentregeln, sammalöneregeln, semestertillägg, sparade dagar, intjänandeår, BAS 2920/7090 accounting |
+| `references/ob-overtime.md` | Questions about OB-tillägg, övertid, Arbetstidslagen limits, CBA divisors, mertid, kompensationsledighet |
+| `references/travel-expenses.md` | Questions about traktamente (domestic/international), tremånadersregeln, meal reductions, utlägg vs kostnadsersättning, milersättning, körjournal |
+| `references/f-skatt.md` | Questions about F-skatt vs A-skatt vs FA-skatt, verification workflow, employer liability, Skatteverket Företagsuppgifter API |
+| `references/bas-7xxx.md` | Questions about BAS kontoplan 7xxx salary accounts, balance sheet accounts (2710/2730/2920), standard monthly journal entry flow |
+| `references/deductions-lonevaxling.md` | Questions about nettolöneavdrag vs bruttolöneavdrag processing order, löneväxling (1.058 factor), pension deductibility caps |
+| `references/sick-pay.md` | Questions about sjuklön, karensavdrag calculation, day 2-14 at 80%, läkarintyg, återinsjuknande, Försäkringskassan day 15+, högkostnadsskydd |
+
+Read multiple reference files when a question spans domains (common).
+
+## Core rates and rules (always in context)
+
+### Arbetsgivaravgifter: 31.42%
+
+Total rate unchanged since 2009. Calculated on full gross salary + taxable benefits with no cap. Age tiers:
+
+| Birth year condition | Rate |
+|---|---|
+| Born 1937 or earlier | 0% |
+| Turned 66+ at year start (67+ from 2026) | 10.21% (only ålderspensionsavgift) |
+| Standard (all others) | 31.42% |
+| Temporary youth 19-23 (Apr 2026 - Sep 2027) | 20.81% on salary up to 25,000 SEK/month |
+
+No avgifter required if total annual compensation from one employer < 1,000 SEK.
+
+### AGI filing deadline
+
+12th of month following pay period (17th in Jan/Aug for turnover ≤40 MSEK). Late = 625 SEK first offense, 1,250 SEK if repeated.
+
+### Skatteavdrag lookup chain
+
+kommun → total skattesats → round to table number (29-42) → select column (1-6 by employee category) → look up gross salary bracket → withholding amount. Sidoinkomst: flat 30%.
+
+### Semesterlön
+
+Procentregeln: 12% of semesterlönegrundande income. Sammalöneregeln: regular pay + 0.43% semestertillägg per day (many CBAs use 0.8%). Intjänandeår: Apr 1 - Mar 31 by law (often calendar year via CBA).
+
+### Sjuklön (day 1-14)
+
+Karensavdrag = 20% of one week's sjuklön (80% of weekly pay). Day 2-14: 80% of lost pay. Läkarintyg from day 8. Återinsjuknande within 5 days = same period continues.
+
+### Traktamente (domestic)
+
+2024-2025: 290 SEK/hel dag. 2026: 300 SEK/hel dag. Halv dag = 50%. After 3 months same location: 70%. After 2 years: 50%.
+
+### Key thresholds 2025
+
+| Parameter | Value |
+|---|---|
+| Prisbasbelopp (PBB) | 58,800 SEK |
+| Inkomstbasbelopp (IBB) | 80,600 SEK |
+| Max PGI (7.5 × IBB) | 604,500 SEK |
+| SGI ceiling (10 × PBB) | 588,000 SEK |
+| Friskvård tax-free cap | 5,000 SEK/year |
+| Milersättning (own car) | 25 SEK/mil |
+| Statlig skatt brytpunkt | 660,400 SEK/year (2026) |
+
+### BAS 7xxx quick reference
+
+| Range | Category |
+|---|---|
+| 7010-7090 | Löner kollektivanställda + semester |
+| 7210-7290 | Löner tjänstemän/företagsledare + semester |
+| 7321-7332 | Traktamente + bilersättningar |
+| 7381-7385 | Förmåner (bostad, kost, bil) |
+| 7410-7460 | Pensionskostnader |
+| 7510-7533 | Arbetsgivaravgifter + SLP |
+| 7571-7699 | Försäkringar + övriga personalkostnader |
+
+### Standard monthly journal entries
+
+1. Gross salary: Debit 7210 / Credit 2710 (tax) + Credit 1930 (net pay)
+2. Employer avgifter: Debit 7510 / Credit 2730
+3. Vacation accrual: Debit 7290 / Credit 2920
+4. Avgifter on accrual: Debit 7519 / Credit 2940
+5. Pension premiums: Debit 7410 / Credit 2440/2740
+6. SLP on pensions: Debit 7533 / Credit 2514
+
+### Processing order for gross-to-net
+
+bruttolöneavdrag → förmånsvärden (reduced by nettolöneavdrag) → tax base → skattetabell lookup → net pay → nettolöneavdrag → utbetalat belopp. Arbetsgivaravgifter calculated on gross after bruttolöneavdrag but before nettolöneavdrag.
+
+### Löneväxling factor
+
+For every 1 SEK salary reduction: pension contribution = 1.058 SEK. Flag if post-reduction salary drops below ~54,204 SEK/month (8.07 × IBB / 12 for 2025).
+
+### F-skatt verification
+
+A-skatt: withhold tax + pay avgifter. F-skatt: neither. FA-skatt: split. No F-skatt stated: withhold 30% + full avgifter. Verify via Skatteverket before first payment.
+
+## Rate update schedule
+
+Rates shift annually with PBB, IBB, and SLR. Subscribe to Skatteverket's annual publications each December. Bilförmån formulas use SLR from November 30 of prior year (floor 0.50%). Kostförmån tied to PBB. Traktamente normalbelopp published annually.

--- a/.claude/skills/swedish-payroll/references/agi-filing.md
+++ b/.claude/skills/swedish-payroll/references/agi-filing.md
@@ -1,0 +1,54 @@
+# Arbetsgivardeklaration (AGI) Filing
+
+## Overview
+
+Since January 2019, every Swedish employer must file a monthly AGI reporting gross pay, withheld tax, benefits, and employer contributions per individual employee (individuppgift) to Skatteverket.
+
+The declaration has two parts: a huvuduppgift (aggregate employer-level totals) and one individuppgift per compensated person.
+
+From January 2025, AGI also includes frånvarouppgifter (parental leave absence data forwarded to Försäkringskassan).
+
+## Filing deadlines
+
+Standard deadline: 12th of the month following the pay period. If the 12th falls on a weekend or holiday, the deadline shifts to the next business day.
+
+Exceptions:
+- January and August: deadline shifts to the 17th for companies with turnover ≤40 MSEK
+- Companies with turnover >40 MSEK: file by the 26th (payment still due by the 12th/17th)
+
+## Key field codes per employee (individuppgift)
+
+| Field code | Content |
+|---|---|
+| FK215 | Employee's personnummer/samordningsnummer |
+| FK570 | Specifikationsnummer (unique per employee per period, must stay consistent for corrections) |
+| Ruta 011 | Kontant bruttolön (gross cash salary) |
+| Ruta 001 | Avdragen skatt (withheld preliminary tax) |
+| Rutor 012-019 | Benefit values by type (bil, bostad, kost, drivmedel, etc.) |
+| Ruta 020 | Underlag för arbetsgivaravgifter |
+| Ruta 131 | Payments to F-skatt holders not subject to social charges |
+| FK821-FK827 | Absence reporting fields (from 2025) |
+
+## XML schema and electronic submission
+
+Skatteverket publishes a Teknisk beskrivning (currently v1.1.18.1) defining the XML file structure, validation rules, and field codes.
+
+Three submission paths:
+1. Manual entry in Skatteverket's e-tjänst
+2. XML file upload via the same portal
+3. API integration through Skatteverket's Utvecklarportal using OAuth2/REST with signed agreements and API keys
+
+A testtjänst (sandbox) is available for XML validation without e-legitimation.
+
+## Corrections
+
+Corrections require resubmitting a complete AGI for the same period with the same specifikationsnummer. If you use a different specifikationsnummer, Skatteverket treats it as an additional record rather than a replacement. This is the most common developer mistake.
+
+## Penalties for late filing
+
+| Situation | Förseningsavgift |
+|---|---|
+| First late filing | 625 SEK |
+| After föreläggande, or late ≥1 of last 3 periods | 1,250 SEK |
+
+Persistent non-filing triggers skönsbeskattning (estimated assessment) and potential F-skatt revocation. Penalties are not tax-deductible (book to account 6992).

--- a/.claude/skills/swedish-payroll/references/bas-7xxx.md
+++ b/.claude/skills/swedish-payroll/references/bas-7xxx.md
@@ -1,0 +1,95 @@
+# BAS Kontoplan 7xxx: Salary Account Mapping
+
+## 70xx: Löner till kollektivanställda
+
+| Account | Name |
+|---|---|
+| 7010 | Löner till kollektivanställda |
+| 7012 | Vinstandelar till kollektivanställda |
+| 7013 | Lön växa-stöd kollektivanställda 10,21% |
+| 7017 | Avgångsvederlag till kollektivanställda |
+| 7018 | Bruttolöneavdrag, kollektivanställda |
+| 7081 | Sjuklöner till kollektivanställda |
+| 7082 | Semesterlöner till kollektivanställda |
+| 7083 | Föräldraersättning till kollektivanställda |
+| 7090 | Förändring av semesterlöneskuld |
+
+## 72xx: Löner till tjänstemän och företagsledare
+
+| Account | Name |
+|---|---|
+| 7210 | Löner till tjänstemän |
+| 7213 | Lön växa-stöd tjänstemän 10,21% |
+| 7218 | Bruttolöneavdrag, tjänstemän |
+| 7220 | Löner till företagsledare |
+| 7222 | Tantiem till företagsledare |
+| 7240 | Styrelsearvoden |
+| 7281 | Sjuklöner till tjänstemän |
+| 7285 | Semesterlöner till tjänstemän |
+| 7290 | Förändring av semesterlöneskuld (tjänstemän) |
+
+## 73xx: Kostnadsersättningar och förmåner
+
+| Account | Name |
+|---|---|
+| 7321 | Skattefria traktamenten, Sverige |
+| 7322 | Skattepliktiga traktamenten, Sverige |
+| 7323 | Skattefria traktamenten, utlandet |
+| 7324 | Skattepliktiga traktamenten, utlandet |
+| 7331 | Skattefria bilersättningar |
+| 7332 | Skattepliktiga bilersättningar |
+| 7381 | Kostnader för fri bostad |
+| 7382 | Kostnader för fria eller subventionerade måltider |
+| 7385 | Kostnader för fri bil |
+
+## 74xx: Pensionskostnader
+
+| Account | Name |
+|---|---|
+| 7410 | Pensionsförsäkringspremier |
+| 7411 | Premier för kollektiva pensionsförsäkringar (ITP, SAF-LO) |
+| 7412 | Premier för individuella pensionsförsäkringar |
+| 7460 | Pensionsutbetalningar |
+
+## 75xx: Sociala avgifter
+
+| Account | Name |
+|---|---|
+| 7510 | Arbetsgivaravgifter 31,42% |
+| 7511 | Arbetsgivaravgifter för löner och ersättningar |
+| 7512 | Arbetsgivaravgifter för förmånsvärden |
+| 7518 | Arbetsgivaravgifter på bruttolöneavdrag |
+| 7519 | Arbetsgivaravgifter för semester- och löneskulder |
+| 7533 | Särskild löneskatt pensionskostnader (24,26%) |
+| 7571 | Arbetsmarknadsförsäkringar (FORA/AFA) |
+| 7581 | Grupplivförsäkringspremier (TGL) |
+
+## 76xx: Övriga personalkostnader
+
+| Account | Name |
+|---|---|
+| 7610 | Utbildning |
+| 7621 | Sjuk- och hälsovård, avdragsgill |
+| 7631 | Personalrepresentation, avdragsgill |
+| 7650 | Sjuklöneförsäkring |
+| 7699 | Övriga personalkostnader (friskvårdsbidrag booked here) |
+
+## Critical balance sheet accounts
+
+| Account | Name | Purpose |
+|---|---|---|
+| 2710 | Personalskatt | Tax withholding liability |
+| 2730 | Lagstadgade sociala avgifter | Employer contribution liability |
+| 2820/2821 | Löneskulder | Net pay liability |
+| 2920 | Upplupna semesterlöner | Vacation pay liability |
+| 2940/2941 | Upplupna lagstadgade sociala avgifter | Social charges on vacation liability |
+| 1630 | Avräkning skatter och avgifter | Tax account at Skatteverket |
+
+## Standard monthly journal entry flow
+
+1. Gross salary: Debit 7210 / Credit 2710 (tax withheld) + Credit 1930 (net pay)
+2. Employer social charges: Debit 7510 / Credit 2730
+3. Vacation accrual: Debit 7290 / Credit 2920
+4. Social charges on accrual: Debit 7519 / Credit 2940
+5. Pension premiums: Debit 7410 / Credit 2440 or 2740
+6. SLP on pensions: Debit 7533 / Credit 2514

--- a/.claude/skills/swedish-payroll/references/benefits.md
+++ b/.claude/skills/swedish-payroll/references/benefits.md
@@ -1,0 +1,81 @@
+# Förmånsbeskattning (Benefit Taxation)
+
+## Bilförmån: three formula generations
+
+The company car benefit formula depends on when the car became taxable (skattepliktigt per vägtrafikskattelagen).
+
+### Generation 3 (cars taxable ≥ July 1, 2021)
+
+```
+Förmånsvärde = (0.29 × PBB) + (nybilspris × (70% × SLR + 1%)) + (13% × nybilspris) + fordonsskatt
+```
+
+### Generation 2 (July 2018 - June 2021)
+
+Same structure but uses 75% × SLR instead of 70%, and the prisrelaterat belopp is 9% up to 7.5 × PBB, then 20% above that threshold.
+
+### Generation 1 (before July 2018)
+
+Uses 0.317 × PBB for the prisbasbeloppsdel, same 75% × SLR factor, same two-tier prisrelaterat belopp, and fordonsskatt is not a separate component.
+
+### SLR (statslåneränta)
+
+Read on November 30 of the prior year (floor 0.50%):
+- 2024: 2.62%
+- 2025: 1.96%
+- 2026: 2.55%
+
+### Nybilspris
+
+Set per model in Skatteverket's billistor, not the actual purchase price. For cars ≥6 years old, minimum nybilspris = 4 × PBB.
+
+### 3,000-mil rule
+
+Reduces the fixed portion by 25% if the employee drives ≥30,000 km/year for work.
+
+### Miljöbil reductions (cars taxable ≥ July 2022)
+
+| Type | Reduction | Cap |
+|---|---|---|
+| Elbil/vätgas | 350,000 SEK off nybilspris | 50% of nybilspris |
+| Laddhybrid | 140,000 SEK off nybilspris | 50% of nybilspris |
+| Gasbil | 100,000 SEK off nybilspris | 50% of nybilspris |
+
+## Kostförmån
+
+Schablonvärden tied to PBB: hel dag = 0.52% × PBB (rounded to nearest 5 SEK), lunch/middag = 40% of hel dag, frukost = 20%.
+
+| Year | Hel dag | Lunch/Middag | Frukost |
+|---|---|---|---|
+| 2024 | 300 SEK | 120 SEK | 60 SEK |
+| 2025 | 305 SEK | 122 SEK | 61 SEK |
+| 2026 | 310 SEK | 124 SEK | 62 SEK |
+
+If the employee pays ≥ schablonvärde via nettolöneavdrag, no taxable benefit arises.
+
+## Friskvårdsbidrag
+
+Tax-free up to 5,000 SEK per employee per year (including moms). If exceeded, the entire amount becomes taxable (not just the excess). Must be offered to all employees on equal terms. Non-motion activities (massage, acupuncture) qualify only if ≤1,000 SEK per occasion. Unchanged for 2024-2026.
+
+Book to account 7699.
+
+## Kvalificerade personaloptioner (KPO)
+
+Under the qualified employee stock option regime (11a kap. IL): no tax at grant or exercise, no arbetsgivaravgifter. Tax deferred to share disposal as capital gains at 30%.
+
+Requirements:
+- Company ≤10 years old
+- <150 employees
+- ≤280 MSEK revenue/balance
+- Intjänandetid ≥3 years
+- Employee works ≥30 hrs/week
+- Compensation ≥13 IBB during vesting period
+
+## Telefon/internet
+
+No fixed schablonvärde. Private use of employer-provided phone/internet is tax-free if:
+- The subscription has a flat fee (cannot separate private use)
+- Is of väsentlig betydelse for the employee's work
+- The private benefit is of limited value
+
+Extra per-use charges (international calls, premium services) are always taxable.

--- a/.claude/skills/swedish-payroll/references/deductions-lonevaxling.md
+++ b/.claude/skills/swedish-payroll/references/deductions-lonevaxling.md
@@ -1,0 +1,56 @@
+# Nettolöneavdrag vs Bruttolöneavdrag and Löneväxling
+
+## Bruttolöneavdrag
+
+Reduces gross salary before tax. Effects:
+- Lowers taxable income
+- Lowers arbetsgivaravgifter
+- Lowers preliminary tax
+- Lowers PGI (future pension)
+- Lowers SGI (sickness benefit base)
+- Does NOT reduce any förmånsvärde
+
+Primary use case: löneväxling till pension. Can only apply to future earnings (never retroactive).
+
+## Nettolöneavdrag
+
+Deducts from net salary after tax has been calculated. Effects:
+- Does NOT affect taxable income, arbetsgivaravgifter, PGI, or SGI
+- DOES reduce the taxable förmånsvärde if the deduction constitutes payment for a specific benefit
+
+Common uses: bilförmån co-payment, parking, lunch subsidies, benefit platform selections.
+
+## Processing order (critical)
+
+1. Apply bruttolöneavdrag
+2. Calculate förmånsvärden (reduced by nettolöneavdrag if applicable)
+3. Determine tax base
+4. Look up tax via skattetabell
+5. Compute net pay
+6. Apply nettolöneavdrag
+7. Arrive at utbetalat belopp
+
+Arbetsgivaravgifter are calculated on gross after bruttolöneavdrag but before any nettolöneavdrag.
+
+## Löneväxling till pension
+
+Employee reduces gross salary; employer pays equivalent plus bonus into tjänstepension. The bonus derives from the tax differential: arbetsgivaravgifter at 31.42% on salary vs SLP at 24.26% on pension contributions.
+
+### The 1.058 factor
+
+For every 1 SEK salary reduction, standard pension contribution = 1.058 SEK (5.8% bonus = employer's saving passed to employee).
+
+```
+pension_contribution = löneväxling_amount × 1.058
+new_gross = original_gross - löneväxling_amount
+employer_cost_on_salary = new_gross × 0.3142
+SLP_on_pension = pension_contribution × 0.2426
+```
+
+### Thresholds to flag
+
+If post-löneväxling salary drops below 8.07 × IBB / 12 (2025: ~54,204 SEK/month), the employee loses pension accrual in allmänna pensionssystemet. Löneväxling also reduces SGI. Software should flag when post-reduction salary approaches this floor.
+
+### Employer pension deductibility cap
+
+35% of pensionsmedförande lön or 10 × PBB/year (2025: 588,000 SEK), whichever is lower.

--- a/.claude/skills/swedish-payroll/references/f-skatt.md
+++ b/.claude/skills/swedish-payroll/references/f-skatt.md
@@ -1,0 +1,27 @@
+# F-skatt vs A-skatt
+
+## Employer obligations by recipient status
+
+| Recipient status | Withhold tax? | Pay arbetsgivaravgifter? |
+|---|---|---|
+| A-skatt (employee) | Yes, per skattetabell | Yes, 31.42% |
+| F-skatt (contractor) | No | No |
+| FA-skatt (employment portion) | Yes, on salary | Yes, on salary |
+| No F-skatt stated | Yes, must withhold 30% | Yes, full contributions |
+
+## Liability
+
+If an employer pays someone without F-skatt and fails to withhold tax, the employer becomes personally liable for both the missing tax and arbetsgivaravgifter.
+
+## Verification
+
+Currently via Skatteverket's "Hämta företagsinformation" e-tjänst (manual lookup by organisationsnummer). A programmatic Företagsuppgifter API is under development on the Utvecklarportal but not yet fully launched.
+
+### Implementation requirements
+- Mandatory verification workflow before first payment to any contractor
+- Store verification date and result
+- Re-verify periodically
+
+## FA-skatt
+
+Applies to individuals with both employment and business income. The employer handles A-skatt + avgifter on the salary portion; the individual handles F-skatt + egenavgifter on business income. Juridiska personer (AB, HB) cannot have FA-skatt.

--- a/.claude/skills/swedish-payroll/references/ob-overtime.md
+++ b/.claude/skills/swedish-payroll/references/ob-overtime.md
@@ -1,0 +1,52 @@
+# Sjuklön (Sick Pay)
+
+## The 14-day employer obligation
+
+Under Sjuklönelagen, the employer pays sick pay for the first 14 calendar days of each sjuklöneperiod.
+
+## Karensavdrag (day 1)
+
+Replaces the old karensdag system (since 2019). Equals 20% of one average week's sjuklön:
+
+```
+average_weekly_pay = (monthly_salary × 12) / 52
+weekly_sjuklön = average_weekly_pay × 0.80
+karensavdrag = weekly_sjuklön × 0.20
+```
+
+For a 30,000 SEK/month employee at 40 hrs/week: karensavdrag ≈ 1,108 SEK.
+
+Only one karensavdrag per sjuklöneperiod. The allmänt högriskskydd limits karensavdrag to maximum 10 per rolling 12-month period. After 10, no further deductions.
+
+## Day 2-14: 80% of lost pay
+
+Sjuklön = 80% of the salary and anställningsförmåner the employee loses due to sickness, calculated per scheduled work hour. Includes regular salary, shift supplements, and scheduled overtime premiums.
+
+### Läkarintyg (medical certificate)
+
+Required from day 8. The employer may require it from day 1 (förstadagsintyg) with written, time-limited justification.
+
+## Återinsjuknande
+
+If the employee falls sick again within 5 calendar days, the same sjuklöneperiod continues (no new karensavdrag). The remaining days of the original 14-day period are used.
+
+## Day 15+: Försäkringskassan
+
+The employer must report to Försäkringskassan within 7 calendar days after the sjuklöneperiod ends.
+
+Sjukpenning rates:
+- ~80% of SGI up to ceiling (10 × PBB, max ~1,284 SEK/day in 2025)
+- Up to 364 days within a 450-day frame
+- Then 75% (fortsättningsnivå)
+
+## Högkostnadsskydd
+
+Abolished July 1, 2024 for general employers. Särskilt högriskskydd (for chronically ill employees) remains: Försäkringskassan reimburses the employer's sjuklönekostnader plus arbetsgivaravgifter.
+
+## BAS accounts
+
+| Account | Purpose |
+|---|---|
+| 7081 | Sjuklöner till kollektivanställda |
+| 7281 | Sjuklöner till tjänstemän |
+| 7650 | Sjuklöneförsäkring |

--- a/.claude/skills/swedish-payroll/references/sick-pay.md
+++ b/.claude/skills/swedish-payroll/references/sick-pay.md
@@ -1,0 +1,52 @@
+# Sjuklön (Sick Pay)
+
+## The 14-day employer obligation
+
+Under Sjuklönelagen, the employer pays sick pay for the first 14 calendar days of each sjuklöneperiod.
+
+## Karensavdrag (day 1)
+
+Replaces the old karensdag system (since 2019). Equals 20% of one average week's sjuklön:
+
+```
+average_weekly_pay = (monthly_salary × 12) / 52
+weekly_sjuklön = average_weekly_pay × 0.80
+karensavdrag = weekly_sjuklön × 0.20
+```
+
+For a 30,000 SEK/month employee at 40 hrs/week: karensavdrag ≈ 1,108 SEK.
+
+Only one karensavdrag per sjuklöneperiod. The allmänt högriskskydd limits karensavdrag to maximum 10 per rolling 12-month period. After 10, no further deductions.
+
+## Day 2-14: 80% of lost pay
+
+Sjuklön = 80% of the salary and anställningsförmåner the employee loses due to sickness, calculated per scheduled work hour. Includes regular salary, shift supplements, and scheduled overtime premiums.
+
+### Läkarintyg (medical certificate)
+
+Required from day 8. The employer may require it from day 1 (förstadagsintyg) with written, time-limited justification.
+
+## Återinsjuknande
+
+If the employee falls sick again within 5 calendar days, the same sjuklöneperiod continues (no new karensavdrag). The remaining days of the original 14-day period are used.
+
+## Day 15+: Försäkringskassan
+
+The employer must report to Försäkringskassan within 7 calendar days after the sjuklöneperiod ends.
+
+Sjukpenning rates:
+- ~80% of SGI up to ceiling (10 × PBB, max ~1,284 SEK/day in 2025)
+- Up to 364 days within a 450-day frame
+- Then 75% (fortsättningsnivå)
+
+## Högkostnadsskydd
+
+Abolished July 1, 2024 for general employers. Särskilt högriskskydd (for chronically ill employees) remains: Försäkringskassan reimburses the employer's sjuklönekostnader plus arbetsgivaravgifter.
+
+## BAS accounts
+
+| Account | Purpose |
+|---|---|
+| 7081 | Sjuklöner till kollektivanställda |
+| 7281 | Sjuklöner till tjänstemän |
+| 7650 | Sjuklöneförsäkring |

--- a/.claude/skills/swedish-payroll/references/social-charges.md
+++ b/.claude/skills/swedish-payroll/references/social-charges.md
@@ -1,0 +1,57 @@
+# Sociala avgifter (Arbetsgivaravgifter)
+
+## Component breakdown
+
+Total: 31.42% (unchanged since 2009). Calculated on full gross with no cap.
+
+| Component | 2024-2025 | 2026 |
+|---|---|---|
+| Ålderspensionsavgift | 10.21% | 10.21% |
+| Sjukförsäkringsavgift | 3.55% | 3.55% |
+| Föräldraförsäkringsavgift | 2.60% | 2.00% |
+| Efterlevandepensionsavgift | 0.60% | 0.30% |
+| Arbetsmarknadsavgift | 2.64% | 2.64% |
+| Arbetsskadeavgift | 0.20% | 0.10% |
+| Allmän löneavgift | 11.62% | 12.62% |
+| **Total** | **31.42%** | **31.42%** |
+
+## Age-based reductions
+
+Check each employee's birth year against calendar year:
+
+- Born 1937 or earlier: 0% (no avgifter)
+- Turned 66 at year's start (born ≤1958 for 2024, ≤1959 for 2025; threshold rises to 67 in 2026): only ålderspensionsavgift = 10.21%
+- Youth discount: abolished January 1, 2024
+- New temporary reduction (Apr 1, 2026 - Sep 30, 2027): 20.81% on salary up to 25,000 SEK/month for ages 19-23
+
+No avgifter required if total annual compensation from a single employer < 1,000 SEK.
+
+## Egenavgifter for sole proprietors
+
+Sole proprietors (enskild firma) pay egenavgifter of 28.97% on business surplus instead of arbetsgivaravgifter.
+
+Key differences from arbetsgivaravgifter:
+- Arbetsmarknadsavgift drops to 0.10% (from 2.64%)
+- Sjukförsäkringsavgift varies by chosen karens days (default 7 days = 3.64%)
+
+7.5% reduction applies on income up to 200,000 SEK/year (max 15,000 SEK saving) for active businesses with surplus >40,000 SEK.
+
+Passive businesses pay särskild löneskatt at 24.26% instead.
+
+## Key thresholds
+
+| Parameter | 2024 | 2025 |
+|---|---|---|
+| Prisbasbelopp (PBB) | 57,300 | 58,800 |
+| Inkomstbasbelopp (IBB) | 76,200 | 80,600 |
+| Max PGI (7.5 × IBB) | 571,500 | 604,500 |
+| Effective pension ceiling (8.07 × IBB) | 614,934 | 650,442 |
+| SGI ceiling (10 × PBB) | 573,000 | 588,000 |
+
+## Special reductions
+
+### Växa-stöd (first-employee discount)
+Only 10.21% on wages up to 25,000 SEK/month (35,000 from 2025) for up to 24 months. Applies to enskild firma or AB hiring their first employee.
+
+### Forskningsavdrag (R&D)
+20% total reduction on qualifying R&D salaries, max 3 MSEK per group per month. Requires systematic research or development work.

--- a/.claude/skills/swedish-payroll/references/tax-tables.md
+++ b/.claude/skills/swedish-payroll/references/tax-tables.md
@@ -1,0 +1,44 @@
+# Skatteavdrag (Tax Tables)
+
+## Tax table lookup system
+
+Employers withhold preliminary tax using skattetabeller published annually by Skatteverket. Each table is numbered 29-42, corresponding to the employee's total municipal tax rate (kommunalskatt + regionskatt + begravningsavgift ± kyrkoavgift).
+
+Rounding rule: fractional part ≤0.50 rounds down, ≥0.51 rounds up to determine the table number.
+
+## Column system
+
+Each table contains 6 columns for different employee categories:
+
+| Column | Applies to |
+|---|---|
+| 1 | Standard employees under 66 (most common) |
+| 2 | Pensioners 66+ |
+| 3 | Workers 66+ with förhöjt jobbskatteavdrag |
+| 4 | Sjuk-/aktivitetsersättning recipients under 66 |
+| 5 | Varies by year per SKVFS |
+| 6 | Pre-65 retirement pensions for born 1951+ |
+
+## Implementation workflow
+
+1. Download Skatteverket's annual skattesatser file (XLSX/TXT) mapping each kommun to its total rate
+2. Determine the employee's folkbokföringskommun from November 1 of the prior year
+3. Apply the rounding rule to get the table number
+4. Select the correct column based on age and income type
+5. Look up the monthly gross salary bracket to find the withholding amount
+
+Skatteverket publishes tables as XLSX, TXT, and PDF, plus open data via the Utvecklarportal. The TXT files follow a fixed-format record structure described in a separate postbeskrivning document.
+
+## Jämkning
+
+Jämkning is a Skatteverket decision adjusting withholding up or down from the table amount. The employee provides a jämkningsbeslut to the employer, who must apply it instead of the table.
+
+## Sidoinkomst
+
+For secondary income (all employers other than the main one), withhold a flat 30% regardless of salary level.
+
+Employees may request förhöjt skatteavdrag (higher withholding) from their main employer without any Skatteverket decision. Lower withholding always requires a jämkning.
+
+## State income tax
+
+The brytpunkt is 660,400 SEK/year (~55,033 SEK/month) for 2026 at 20% above the threshold. This is already built into the published tax tables, so no separate employer calculation is needed.

--- a/.claude/skills/swedish-payroll/references/travel-expenses.md
+++ b/.claude/skills/swedish-payroll/references/travel-expenses.md
@@ -1,0 +1,65 @@
+# Traktamente and Utlägg
+
+## Domestic traktamente
+
+Tax-free domestic traktamente requires a tjänsteresa with overnight stay, destination ≥50 km from both home and workplace, with documented reseräkning.
+
+| Period | Hel dag | Halv dag | Nattraktamente |
+|---|---|---|---|
+| 2024-2025 | 290 SEK | 145 SEK | 145 SEK |
+| 2026 | 300 SEK | 150 SEK | 150 SEK |
+
+### Day type rules
+
+Departure before 12:00 or return after 19:00 = hel dag. Otherwise halv dag. Intermediate days are always hela dagar.
+
+### Tremånadersregeln
+
+After 3 consecutive months at the same location: rate drops to 70% of maximibelopp. After 2 years: drops to 50%. A break of ≥4 weeks resets the counter.
+
+### Meal reductions (2025, traktamente = 290 SEK)
+
+| Meals provided | Reduction | Remaining |
+|---|---|---|
+| Frukost only | 58 SEK (20%) | 232 SEK |
+| Lunch or middag | 102 SEK (35.2%) | 188 SEK |
+| Lunch and middag | 203 SEK (70%) | 87 SEK |
+| All three meals | 261 SEK (90%) | 29 SEK |
+
+When meals are provided and traktamente reduced, a kostförmån for the free meal is also triggered (both apply simultaneously). Meals included in transport tickets do not trigger a reduction.
+
+### International traktamente
+
+Uses country-specific normalbelopp published annually by Skatteverket. Same 3-month, 2-year, and meal reduction percentage rules apply.
+
+## Utlägg vs kostnadsersättning
+
+| Characteristic | Utlägg (employer's expense) | Kostnadsersättning (employee's cost) |
+|---|---|---|
+| Receipt belongs to | The company | The employee |
+| Taxable income? | No | No, if within skattefria schabloner |
+| Arbetsgivaravgifter? | No | No, if within schabloner |
+| On lönespec? | No (or info only) | Yes, listed separately |
+| Example | Office supplies, client lunch | Milersättning, traktamente |
+
+For purchases >4,000 SEK including moms, the employer's name must appear on the receipt for VAT deduction.
+
+## Milersättning
+
+Unchanged 2024-2026:
+- Own car: 25 SEK/mil (2.50 SEK/km)
+- Förmånsbil (petrol/diesel): 12 SEK/mil
+- Förmånsbil (electric/hybrid): 9.50 SEK/mil
+
+Amounts exceeding schabloner are taxed as salary with full arbetsgivaravgifter. All reimbursements require a körjournal with dates, mileage readings, destinations, and business purpose. Retention: 7 years per bokföringslagen.
+
+## BAS accounts
+
+| Account | Purpose |
+|---|---|
+| 7321 | Skattefria traktamenten, Sverige |
+| 7322 | Skattepliktiga traktamenten, Sverige |
+| 7323 | Skattefria traktamenten, utlandet |
+| 7324 | Skattepliktiga traktamenten, utlandet |
+| 7331 | Skattefria bilersättningar |
+| 7332 | Skattepliktiga bilersättningar |

--- a/.claude/skills/swedish-payroll/references/vacation-pay.md
+++ b/.claude/skills/swedish-payroll/references/vacation-pay.md
@@ -1,0 +1,47 @@
+# Semesterlöneskuld (Vacation Pay)
+
+## Two calculation methods
+
+### Sammalöneregeln (§16a Semesterlagen)
+
+Default for monthly-salaried employees. Regular salary continues during vacation, plus a semestertillägg of minimum 0.43% of monthly salary per vacation day (many CBAs use 0.8%). An additional 12% of variable pay (OB, overtime, bonuses) earned during the intjänandeår is divided by earned days and paid per taken day.
+
+### Procentregeln (§16)
+
+Applies to hourly employees, those with >10% variable pay, or when sammalöneregeln cannot be used. Semesterlön = 12% of total semesterlönegrundande income during the intjänandeår. For entitlements beyond 25 days, add 0.48 percentage points per extra day (e.g., 30 days = 14.4%).
+
+## Intjänandeår
+
+Runs April 1 - March 31 by law, but many collective agreements use sammanfallande (concurrent) calendar-year periods. Developers must make this configurable.
+
+## Accounting entries (BAS accounts)
+
+| Account | Purpose |
+|---|---|
+| 2920 | Upplupna semesterlöner (vacation pay liability, balance sheet) |
+| 2940/2941 | Upplupna sociala avgifter på semesterlöner |
+| 7090 | Förändring av semesterlöneskuld, kollektivanställda (P&L) |
+| 7290/7291/7292 | Förändring av semesterlöneskuld, tjänstemän/företagsledare (P&L) |
+| 7519 | Arbetsgivaravgifter för semester- och löneskulder (P&L) |
+
+### Monthly accrual
+
+Debit 7090/7290 and credit 2920 for new vacation pay earned. Debit 7519 and credit 2940 for social charges on the accrual (31.42% for standard employees, 10.21% for 67+).
+
+### Vacation taken
+
+Reverse: debit 2920 / credit 7090 or 7290.
+
+### Liability calculation
+
+Must be calculated individually per employee under BFNAR 2016:10.
+
+## Sparade semesterdagar
+
+Employees with >20 paid days may save the excess (max 5 from a 25-day entitlement), up to 5 years. Saved days are valued using the most recent intjänandeår's calculation.
+
+Upon termination, all untaken days must be paid as semesterersättning within 1 month.
+
+## Semesterlönegrundande frånvaro
+
+Certain absences count as if worked for vacation accrual purposes: sjukfrånvaro (first 180 days), föräldraledighet (first 120 days for first child, 60 for additional), studieledighet with stipend, and more. See Semesterlagen §17-17b for complete list.

--- a/.claude/skills/swedish-vat/SKILL.md
+++ b/.claude/skills/swedish-vat/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: swedish-vat
+description: >
+  Swedish VAT (moms) compliance reference. Covers momsredovisning periods/deadlines, EU VAT (omvänd skattskyldighet, reverse charge, tjänstehandel, varuhandel, trepartshandel, OSS), import/export moms, representation moms (300 SEK cap), mixed verksamhet (proportionell avdragsrätt, HFD 2023 ref. 45), jämkning of input VAT on capital goods, frivillig skattskyldighet for uthyrning, momsdeklaration Ruta 05-62 to BAS 26xx mapping, complete BAS 26xx series, error patterns, penalties, and law references (ML 2023:200, SFL, EU VAT Directive). Trigger on ANY Swedish moms/VAT question, momsdeklaration, EU trade VAT, reverse charge, representation, blandad verksamhet, jämkning, BAS 2610-2670, rutor 05-62, "vilken momskod", "hur bokför jag moms", "omvänd moms", "EU-moms", "importmoms". Highest-error-rate area in Swedish bookkeeping; always use this skill over training data.
+---
+
+# Swedish VAT (Moms) Compliance Skill
+
+This skill provides authoritative compliance reference for Swedish VAT. It is the **single highest-error-rate area** in Swedish bookkeeping.
+
+## When to use
+
+Always read the full reference before answering ANY question about:
+
+- Momsredovisning periods, thresholds, deadlines
+- EU VAT: reverse charge, intra-EU goods/services, triangulation, OSS
+- Import/export VAT
+- Representation moms (deduction limits, BAS accounts)
+- Mixed activities (proportional deduction, HFD 2023 ref. 45)
+- Jämkning (adjustment of input VAT on capital goods)
+- Frivillig skattskyldighet for property rental
+- Momsdeklaration field-to-BAS account mapping
+- BAS 26xx account usage
+- VAT error patterns, penalties, skattetillägg
+
+## How to use
+
+1. **Read the full reference first:** `view /path/to/this/skill/references/vat-compliance-reference.md`
+2. Find the relevant section for the user's question
+3. Provide precise answers with account numbers, ruta numbers, legal references, and thresholds
+4. Flag common error patterns relevant to the user's scenario
+
+## Quick reference: VAT rates
+
+| Rate | Applies to |
+|------|-----------|
+| 25% | Default rate, most goods and services |
+| 12% | Food, hotel, restaurant, camping (drops to 6% for food from April 2026) |
+| 6% | Books, newspapers, transport, cultural events, sports, repairs (bicycles/shoes/clothing) |
+| 0% | Exports outside EU, intra-EU supplies (with conditions) |
+
+## Quick reference: Key BAS accounts
+
+| Account | Purpose | Momsdeklaration |
+|---------|---------|-----------------|
+| 2611 | Utgående moms domestic 25% | Ruta 10 |
+| 2614 | Utgående moms reverse charge 25% | Ruta 30 |
+| 2615 | Utgående moms import 25% | Ruta 60 |
+| 2641 | Debiterad ingående moms | Ruta 48 |
+| 2645 | Beräknad ingående moms förvärv utlandet | Ruta 48 |
+| 2650 | Momsredovisningskonto (clearing) | Ruta 49 |
+
+## Quick reference: Reporting thresholds
+
+| Annual beskattningsunderlag | Default period |
+|----------------------------|----------------|
+| ≤ 1M SEK | Annual |
+| > 1M - ≤ 40M SEK | Quarterly |
+| > 40M SEK | Monthly |
+
+## Critical error patterns to flag
+
+1. **2611 vs 2614**: Reverse charge output VAT must go to 2614 (Ruta 30), never 2611 (Ruta 10)
+2. **One-sided reverse charge**: Both output AND input VAT must be booked; silent netting is prohibited
+3. **Import double-counting**: Since 2015, VAT-registered businesses report import VAT to Skatteverket only, not Tullverket
+4. **Representation**: VAT deductible on 300 SEK base; income tax deduction abolished for meals since 2017
+5. **Period-end clearing**: All 261x-264x must clear to 2650; residual balances cause reconciliation failures
+
+For the complete reference with all account mappings, legal citations, formulas, and detailed rules, read:
+`references/vat-compliance-reference.md`

--- a/.claude/skills/swedish-vat/references/vat-compliance-reference.md
+++ b/.claude/skills/swedish-vat/references/vat-compliance-reference.md
@@ -1,0 +1,502 @@
+# Swedish VAT (Moms) Complete Compliance Reference
+
+## Table of Contents
+
+1. [Momsredovisning Periods, Thresholds, Deadlines](#1-momsredovisning-periods-thresholds-and-deadlines)
+2. [EU VAT Rules in Sweden](#2-eu-vat-rules-in-sweden)
+3. [Representation Moms Rules](#3-representation-moms-rules-for-2024-2026)
+4. [Mixed Verksamhet / Proportional Deduction](#4-mixed-verksamhet-and-proportional-deduction)
+5. [Jämkning of Input VAT on Capital Goods](#5-jämkning-of-input-vat-on-capital-goods)
+6. [Frivillig Skattskyldighet for Property Rental](#6-frivillig-skattskyldighet-for-property-rental)
+7. [Momsdeklaration Field-to-BAS Account Mapping](#7-momsdeklaration-field-to-bas-account-mapping)
+8. [Complete BAS 26xx Account Series](#8-complete-bas-26xx-account-series)
+9. [Common Error Patterns and Penalties](#9-highest-frequency-error-patterns)
+10. [Key Law References](#10-key-law-references)
+
+---
+
+## 1. Momsredovisning Periods, Thresholds, and Deadlines
+
+Swedish VAT reporting periods are governed by SFL 26 kap. 10-11 §§. The determining factor is the company's beskattningsunderlag (taxable base excluding VAT), specifically excluding unionsinterna förvärv and imports.
+
+### Threshold structure
+
+| Beskattningsunderlag per year | Default period | Alternatives |
+|------|------|------|
+| ≤ 1 million SEK | Full beskattningsår (annual) | Quarterly or monthly (voluntary) |
+| > 1M - ≤ 40 million SEK | Kalenderkvartal (quarterly) | Monthly (voluntary) |
+| > 40 million SEK | Kalendermånad (monthly) | None |
+
+Unchanged since 2008 (Prop. 2007/08:25). VAT registration exemption threshold raised from 80,000 SEK to 120,000 SEK effective 1 January 2025 (Prop. 2023/24:149).
+
+### Filing deadlines: Monthly filers
+
+**Beskattningsunderlag ≤ 40M SEK:** Deadline is the 12th of the second month after period ends. In January and August, deadline shifts to the 17th (26 kap. 26 § SFL).
+
+**Beskattningsunderlag > 40M SEK:** Deadline is the 26th of the month after period ends, with 27th applying in December (26 kap. 30 § SFL).
+
+### Filing deadlines: Quarterly filers
+
+12th of the second month after quarter-end, with 17th in August.
+
+| Quarter | Deadline |
+|------|------|
+| Jan-Mar | 12 May |
+| Apr-Jun | 17 August |
+| Jul-Sep | 12 November |
+| Oct-Dec | 12 February (following year) |
+
+### Filing deadlines: Annual filers
+
+Enskild näringsidkare without EU trade: 12 May following year (byråanstånd to 26 June). With EU trade: 26 February. Juridiska personer: varies by räkenskapsår end-date and filing method (26 kap. 33-33b §§ SFL).
+
+Weekend/holiday deadlines move to the next business day. Payment must reach Skattekontot by filing deadline (62 kap. 3 § SFL).
+
+### Switching periods
+
+Any business can request a shorter period (26 kap. 13 § 1st para, point 1 SFL). 24-month lock-in before switching back to longer period (26 kap. 13 § 2nd para SFL). Switch to quarterly takes effect after current quarter ends (26 kap. 15 § SFL). Turnover threshold crossings require Skatteverket notification (7 kap. 4 § SFL).
+
+### Accounting method interaction
+
+Faktureringsmetoden (accrual) required for omsättning > 3 million SEK. Bokslutsmetoden (cash) available for ≤ 3M SEK; VAT recognized on payment except at year-end.
+
+---
+
+## 2. EU VAT Rules in Sweden
+
+### 2.1 Omvänd skattskyldighet (reverse charge)
+
+Buyer self-assesses both output and input VAT. Applies in two contexts:
+
+**EU cross-border:** Intra-community goods acquisitions, B2B service purchases under main rule, purchases from non-EU suppliers.
+
+**Domestic:** Byggtjänster (construction, between VAT-registered construction businesses), avfall och skrot (scrap metal), guldmaterial (≥ 325 thousandths), mobiltelefoner/datorer/spelkonsoler (invoice > SEK 100,000, since April 2021).
+
+**BAS accounts and booking for reverse charge:**
+
+| Account | Role | Momsdeklaration |
+|------|------|------|
+| 2614 | Utgående moms, omvänd betalningsskyldighet 25% | Ruta 30 |
+| 2624 | Utgående moms, omvänd betalningsskyldighet 12% | Ruta 31 |
+| 2634 | Utgående moms, omvänd betalningsskyldighet 6% | Ruta 32 |
+| 2645 | Beräknad ingående moms på förvärv från utlandet | Ruta 48 |
+| 2647 | Ingående moms, omvänd betalningsskyldighet varor/tjänster i Sverige | Ruta 48 |
+
+Standard journal entry (EU consulting at 25%): Debit cost account + 2645, credit 2614 + leverantörsskulder (2440). Net VAT effect is zero with full deduction right. BOTH sides must be reported; silent netting is prohibited.
+
+### 2.2 Trade in services within EU
+
+**Huvudregeln** (ML 6 kap. 34 §, Article 44 VAT Directive): B2B services taxed where buyer established.
+
+Swedish seller: Invoice without VAT, reference "reverse charge," include buyer VAT number. Report in Ruta 39 + periodisk sammanställning.
+
+Swedish buyer receiving EU services: Report purchase in Ruta 21, self-assess output VAT in Ruta 30/31/32, claim input VAT in Ruta 48.
+
+**Exceptions** (taxed where performed): Fastighetstjänster (property location), persontransporter (where transport occurs), korttidsuthyrning transport vehicles (pickup location), restaurang/catering (where performed), admission to cultural/sports events (event location).
+
+B2C: Generally taxed where seller established. Exception: electronic services, telecom, broadcasting (destination principle since 2015).
+
+### 2.3 Trade in goods within EU
+
+**Gemenskapsinterna förvärv (intra-community acquisitions):** Swedish buyer provides VAT number, receives invoice without VAT, self-assesses. Purchase in Ruta 20, output VAT in Ruta 30/31/32, input VAT in Ruta 48. Cost accounts: 4515/4516/4517 (25%/12%/6%).
+
+**Gemenskapsintern försäljning (intra-community supply):** Zero-rated if four conditions met: valid buyer VAT number (verified via VIES), physical transport from Sweden to another EU country, at least two independent transport documents, reporting in periodisk sammanställning. Reported in Ruta 35, BAS account 3108.
+
+**Trepartshandel (triangulation):** Intermediary (B) avoids VAT registration in destination country. B reports purchases in Ruta 37, sales in Ruta 38, no output/input VAT. Must include in periodisk sammanställning under trepartshandel column. BAS: 4512 (purchase), 3107 (sale).
+
+**Chain transactions (Quick Fixes 2020):** Transport attributed to supply made to the intermediary (if intermediary arranges transport). If intermediary provides departure-country VAT number to supplier, transport attributed to supply made by intermediary. ML 5 kap. 22-25 §.
+
+### 2.4 Distance selling and OSS
+
+Aggregate threshold for B2C distance sales across all EU: EUR 10,000 (≈ SEK 99,680). Above this, destination-country VAT applies. OSS via Skatteverket for quarterly declarations. BAS 2670 handles OSS output VAT. OSS transactions NOT on standard momsdeklaration.
+
+### 2.5 Import and export VAT
+
+Since 1 January 2015, VAT-registered businesses report import VAT in momsdeklaration to Skatteverket (not Tullverket). Only customs duties to Tullverket.
+
+Import tax base (Ruta 50): tullvärde + duties + ancillary costs. Output VAT in Ruta 60/61/62. Input VAT in Ruta 48. BAS: 2615/2625/2635 (output), 2641 (input), 4545/4546/4547 (beschattningsunderlag).
+
+Non-VAT-registered importers: Tullverket collects import VAT directly.
+
+Exports outside EU: 0% moms, full avdragsrätt retained. Ruta 36, BAS 3105. Proof requires customs/freight documentation.
+
+### 2.6 Periodisk sammanställning (EC Sales List)
+
+Required for VAT-registered businesses selling goods/services to VAT-registered EU buyers. Monthly for goods (or goods + services), quarterly for services-only. Electronic deadline: 25th of month after period; paper: 20th (35 kap. 9 § SFL). Late filing penalty: SEK 1,250 per report (52 kap. 10 § SFL). No extension available. Amounts must match Ruta 35 + 38 (goods) and Ruta 39 (services).
+
+---
+
+## 3. Representation Moms Rules for 2024-2026
+
+2017 reform: Income tax deduction for representation meals abolished entirely. Only enklare förtäring (simple refreshments) deductible at 60 SEK/person/occasion for income tax. VAT deduction on representation meals retained.
+
+### VAT deduction limits
+
+Max beskattningsunderlag: 300 SEK excl. moms per person per occasion.
+
+| Scenario | Max VAT deduction per person |
+|------|------|
+| Food only (12% VAT) | 300 × 12% = 36 SEK |
+| Food + alcohol (mixed 12%/25%) | Schablon 46 SEK |
+| All at 25% VAT | 300 × 25% = 75 SEK |
+| Events/entertainment | Max base 180 SEK/person |
+| Representationsgåvor | Max base 300 SEK/person |
+
+**April 2026 change:** Food VAT drops from 12% to 6%, reducing food-only schablon to ~18 SEK (or 33 SEK per updated Skatteverket guidance).
+
+Dual-track: A 500 SEK/person dinner is NOT deductible for income tax but VAT IS deductible on first 300 SEK base.
+
+### BAS accounts for representation
+
+| Account | Purpose |
+|------|------|
+| 6071 | Representation, avdragsgill (income-tax-deductible) |
+| 6072 | Representation, ej avdragsgill |
+| 7631 | Personalrepresentation, avdragsgill |
+| 7632 | Personalrepresentation, ej avdragsgill |
+| 2641 | Ingående moms (deductible VAT portion) → Ruta 48 |
+
+Non-deductible VAT booked as cost, not claimed on momsdeklaration.
+
+### Legal basis
+
+ML 13 kap. 24-25 §§. IL 16 kap. 2 §. Ställningstagande: Dnr 131 519171-16/111 (2016-12-21); Dnr 202 416536-17/111.
+
+---
+
+## 4. Mixed Verksamhet and Proportional Deduction
+
+When business has both VAT-taxable and VAT-exempt activities: directly attributable costs get full/no deduction; shared costs (gemensamma kostnader) require proportional allocation.
+
+### Two methods after HFD 2023 ref. 45
+
+**Method 1 - Skälig grund (ML 13 kap. 29 §):** Allocation on "reasonable basis" reflecting actual resource use. Keys: omsättning, yta, arbetstid, produktionskostnad. Minimum two decimal places.
+
+**Method 2 - EU turnover method (Articles 173.1, 174):** Taxable turnover ÷ total turnover (both excl. VAT). Result rounded UP to next whole number (Article 175.1). Prior year's proportion usable provisionally with year-end adjustment.
+
+Taxpayers may combine methods per cost category, choosing whichever gives better result. Confirmed by Skatteverket Dnr 8-2749853 (2024-02-05) and HFD 2025 not. 29.
+
+### 95% rules (ML 13 kap. 30 §)
+
+If shared purchase used > 95% in taxable part: full input VAT deduction permitted. If > 95% of total turnover is taxable AND input VAT on specific shared purchase ≤ SEK 1,000: full deduction permitted.
+
+### BAS accounts
+
+| Account | Purpose |
+|------|------|
+| 2649 | Ingående moms, blandad verksamhet (deductible portion) → Ruta 48 |
+| 6999 | Ingående moms, blandad verksamhet (non-deductible portion as cost) |
+
+Proportion recalculated annually based on actual turnover with year-end adjustments.
+
+### Proposed changes effective 1 January 2027
+
+Omsättningsmetoden as explicit statutory default. Area-based method (ytbaserad) for building costs. Per-verksamhetsgren calculation.
+
+---
+
+## 5. Jämkning of Input VAT on Capital Goods
+
+Renamed "justering" in ML 2023:200, 15 kap. Requires correction of previously deducted input VAT when capital good use changes during adjustment period.
+
+### Adjustment periods and thresholds
+
+| Asset type | Period | Min ingående moms | Equiv. anskaffningsvärde |
+|------|------|------|------|
+| Lös egendom (machinery, vehicles) | 5 years | ≥ 50,000 SEK | ≥ 200,000 SEK excl. moms |
+| Fastighet (buildings, ny-/till-/ombyggnad) | 10 years | ≥ 100,000 SEK per tax year | ≥ 400,000 SEK excl. moms |
+
+Period starts from acquisition (movable) or completion (real property). Acquisition/completion year = year 1. Each asset assessed separately for threshold. For real property, all work on same fastighet within single tax year IS aggregated.
+
+### Triggers for jämkning
+
+Changed usage between taxable/exempt (assessed at year-end vs acquisition), sale/transfer, demolition, cessation of frivillig skattskyldighet, verksamhetsöverlåtelse. Minimum change: ≥ 5 percentage points.
+
+### Calculation formulas
+
+**Annual adjustment (changed usage):**
+Annual jämkning = Original ingående moms × Change in avdragsandel × 1/N (N = 5 or 10)
+
+**One-time adjustment (sale/cessation):**
+Slutjämkning = Original ingående moms × Change in avdragsandel × Remaining years / Total years
+
+Example: Warehouse renovated Year 1, 500,000 SEK ingående moms fully deducted, shifts to 60% taxable Year 3: 500,000 × (-40%) × 1/10 = -20,000 SEK (repayment for Year 3).
+
+### EU law: C-787/18 (Sögård Fastigheter)
+
+Swedish rules on transferring jämkningsskyldighet to property buyers incompatible with EU law. Skatteverket confirmed transfer rules no longer applied. Legislative reform: SOU 2026:24 (26 March 2026), lagrådsremiss 1 April 2026.
+
+### BAS accounts
+
+Negative jämkning (repayment): credit 2640/2641, debit cost/asset account. Positive jämkning: reverse. Reported in Ruta 48. Account 2648 (vilande ingående moms) for construction phase before frivillig beskattning granted.
+
+---
+
+## 6. Frivillig Skattskyldighet for Property Rental
+
+ML 12 kap. Allows property owners to charge 25% VAT on commercial rental, unlocking input VAT deductions on property costs. Without this, rental is VAT-exempt, creating dold moms.
+
+### Requirements
+
+Tenant must use premises for VAT-taxable activities (or blandad verksamhet). Rental to stat/kommun/kommunalförbund qualifies regardless. Lease must cover klart avgränsad del of building, provide stadigvarande användning (≥ 1 year or undefined period), premises must not be stadigvarande bostad.
+
+### Activation
+
+Landlord issues hyresavi with 25% moms within 6 months of rental period start. No Skatteverket application needed unless activating during construction (form SKV 5704).
+
+### Chain requirement
+
+Each link in subletting chain must maintain frivillig beskattning. Max three rental links (owner → first-hand → second-hand → end user). If any link fails to charge moms or end-user is exempt, entire chain above loses frivillig beskattning for that lokal, potentially triggering jämkning.
+
+### Interaction with jämkning
+
+If frivillig beskattning ceases: landlord must repay previously deducted investeringsmoms for remaining korrigeringstid. Example: 4,000,000 SEK deducted renovation VAT, loses voluntary registration year 3: repayment = 4,000,000 × 7/10 = 2,800,000 SEK. Landlords should include momsklausuler in leases.
+
+### BAS accounts
+
+| Account | Purpose |
+|------|------|
+| 2613 | Utgående moms för uthyrning, 25% |
+| 2642 | Debiterad ingående moms, frivillig betalningsskyldighet |
+| 2646 | Ingående moms på uthyrning |
+| 2648 | Vilande ingående moms (construction phase) |
+| 3913 | Hyresintäkter (frivilligt momspliktiga) |
+
+---
+
+## 7. Momsdeklaration Field-to-BAS Account Mapping
+
+Complete mapping for SKV 4700.
+
+### Section A - Taxable sales (belopp excl. VAT)
+
+| Ruta | Label | BAS accounts |
+|------|------|------|
+| 05 | Momspliktig försäljning ej i annan ruta | 3001/3002/3003, 35xx |
+| 06 | Momspliktiga uttag | 3401, 3402, 3403 |
+| 07 | Beskattningsunderlag vid vinstmarginalbeskattning | 3211, 3212, 3220 |
+| 08 | Hyresinkomster vid frivillig skattskyldighet | 3913 |
+
+### Section B - Output VAT on sales (moms amounts)
+
+| Ruta | Label | BAS accounts |
+|------|------|------|
+| 10 | Utgående moms 25% | 2611, 2612, 2613, 2616 |
+| 11 | Utgående moms 12% | 2621, 2622, 2623, 2626 |
+| 12 | Utgående moms 6% | 2631, 2632, 2633, 2636 |
+
+### Section C - Reverse charge purchases (belopp excl. VAT)
+
+| Ruta | Label | BAS accounts |
+|------|------|------|
+| 20 | Inköp varor annat EU-land | 4515, 4516, 4517 |
+| 21 | Inköp tjänster annat EU-land (huvudregeln) | 4535, 4536, 4537 |
+| 22 | Inköp tjänster land utanför EU | 4531, 4532, 4533 |
+| 23 | Inköp varor i Sverige (köparen betalningsskyldig) | 4415, 4416, 4417 |
+| 24 | Övriga inköp tjänster i Sverige (köparen betalningsskyldig) | 4425, 4426, 4427 |
+
+### Section D - Output VAT on reverse charge (moms amounts)
+
+| Ruta | Label | BAS accounts |
+|------|------|------|
+| 30 | Utgående moms 25% | 2614 |
+| 31 | Utgående moms 12% | 2624 |
+| 32 | Utgående moms 6% | 2634 |
+
+### Section E - VAT-exempt sales (belopp)
+
+| Ruta | Label | BAS accounts |
+|------|------|------|
+| 35 | Försäljning varor till annat EU-land | 3108 |
+| 36 | Försäljning varor utanför EU | 3105 |
+| 37 | Mellanmans inköp vid trepartshandel | 4512 |
+| 38 | Mellanmans försäljning vid trepartshandel | 3107 |
+| 39 | Försäljning tjänster till EU (huvudregeln) | 3308 |
+| 40 | Övrig försäljning tjänster omsatta utom landet | 3305 |
+| 41 | Försäljning när köparen betalningsskyldig i Sverige | 3231, 3232, 3233 |
+| 42 | Övrig försäljning mm | 3004, 3404, 3994, 3980 |
+
+### Section H - Import tax base (belopp)
+
+| Ruta | Label | BAS accounts |
+|------|------|------|
+| 50 | Beskattningsunderlag vid import | 4545, 4546, 4547 |
+
+### Section I - Output VAT on imports (moms amounts)
+
+| Ruta | Label | BAS accounts |
+|------|------|------|
+| 60 | Utgående moms 25% import | 2615 |
+| 61 | Utgående moms 12% import | 2625 |
+| 62 | Utgående moms 6% import | 2635 |
+
+### Section F - Input VAT
+
+| Ruta | Label | BAS accounts |
+|------|------|------|
+| 48 | Ingående moms att dra av | 2641 + 2645 + 2646 + 2647 + 2649 (deductible only) |
+
+### Section G - Net VAT
+
+| Ruta | Label | BAS accounts |
+|------|------|------|
+| 49 | Moms att betala eller få tillbaka | 2650 (settlement) |
+
+**Formula:** (Ruta 10 + 11 + 12 + 30 + 31 + 32 + 60 + 61 + 62) - Ruta 48 = Ruta 49
+
+---
+
+## 8. Complete BAS 26xx Account Series
+
+### 261x - Utgående moms 25%
+
+| Account | Name | Purpose | Ruta |
+|------|------|------|------|
+| 2610 | Utgående moms, 25% | Summary account | 10 |
+| 2611 | Utgående moms försäljning inom Sverige, 25% | Standard domestic | 10 |
+| 2612 | Utgående moms egna uttag, 25% | Owner withdrawals | 10 |
+| 2613 | Utgående moms uthyrning, 25% | Frivillig skattskyldighet | 10 |
+| 2614 | Utgående moms omvänd betalningsskyldighet, 25% | All reverse charge | **30** |
+| 2615 | Utgående moms import, 25% | Import VAT (since 2015) | **60** |
+| 2616 | Utgående moms VMB 25% | Profit margin scheme | 10 |
+| 2618 | Vilande utgående moms, 25% | Dormant/pending | Transferred |
+
+### 262x - Utgående moms 12%
+
+| Account | Name | Purpose | Ruta |
+|------|------|------|------|
+| 2620 | Utgående moms, 12% | Summary account | 11 |
+| 2621 | Utgående moms försäljning inom Sverige, 12% | Food, hotel, restaurant | 11 |
+| 2622 | Utgående moms egna uttag, 12% | Owner withdrawals | 11 |
+| 2623 | Utgående moms uthyrning, 12% | Rental | 11 |
+| 2624 | Utgående moms omvänd betalningsskyldighet, 12% | Reverse charge | **31** |
+| 2625 | Utgående moms import, 12% | Import | **61** |
+| 2626 | Utgående moms VMB 12% | Profit margin | 11 |
+| 2628 | Vilande utgående moms, 12% | Dormant | Transferred |
+
+### 263x - Utgående moms 6%
+
+| Account | Name | Purpose | Ruta |
+|------|------|------|------|
+| 2630 | Utgående moms, 6% | Summary account | 12 |
+| 2631 | Utgående moms försäljning inom Sverige, 6% | Books, transport, culture | 12 |
+| 2632 | Utgående moms egna uttag, 6% | Owner withdrawals | 12 |
+| 2633 | Utgående moms uthyrning, 6% | Rental | 12 |
+| 2634 | Utgående moms omvänd betalningsskyldighet, 6% | Reverse charge | **32** |
+| 2635 | Utgående moms import, 6% | Import | **62** |
+| 2636 | Utgående moms VMB 6% | Profit margin | 12 |
+| 2638 | Vilande utgående moms, 6% | Dormant | Transferred |
+
+### 264x - Ingående moms
+
+| Account | Name | Purpose | Ruta |
+|------|------|------|------|
+| 2640 | Ingående moms | Summary account (all rates) | 48 |
+| 2641 | Debiterad ingående moms | Standard invoiced input VAT | 48 |
+| 2642 | Debiterad ingående moms, frivillig betalningsskyldighet | Voluntary rental input VAT | 48 |
+| 2645 | Beräknad ingående moms förvärv utlandet | Reverse charge input (EU + non-EU) | 48 |
+| 2646 | Ingående moms på uthyrning | Rental operations input VAT | 48 |
+| 2647 | Ingående moms omvänd betalningsskyldighet i Sverige | Domestic reverse charge input | 48 |
+| 2648 | Vilande ingående moms | Dormant (construction phase) | Transferred |
+| 2649 | Ingående moms blandad verksamhet | Deductible portion mixed activities | 48 |
+
+### 265x-267x - Settlement, excise, OSS
+
+| Account | Name | Purpose |
+|------|------|------|
+| 2650 | Redovisningskonto för moms | Clearing; net = Ruta 49 |
+| 2660 | Punktskatter | Excise (not on momsdeklaration) |
+| 2670 | Utgående moms försäljning inom EU, OSS | OSS (separate declaration) |
+
+**Historical note:** Before 2015, 2615/2625/2635 were for EU acquisition output VAT. Since 2015, exclusively for import VAT (Ruta 60-62). Account 2614 now handles all reverse charge (EU + domestic). Legacy system migration must remap.
+
+---
+
+## 9. Highest-Frequency Error Patterns
+
+### Rate misclassification
+
+Wrong VAT rate is the most common SME error. Confusion points: restaurant vs. takeaway food (both 12% but alcohol triggers 25% splitting), digital products (e-books 6% vs. SaaS 25%), mixed hotel packages, repair services (reduced rates only for specific categories: bicycles, shoes, leather goods, clothing, household linen).
+
+### EU trade errors
+
+Forgetting reverse charge on EU purchases entirely (neither output nor input VAT reported). Common for IT services, advertising platforms (Google, Meta), consulting from EU suppliers. Also: missing periodisk sammanställning, not validating buyer VAT via VIES, zero-rating without transport documentation.
+
+### Reverse charge booking errors
+
+Posting reverse charge output VAT to 2611 instead of 2614 (inflates Ruta 10 instead of Ruta 30). Booking only one side of reverse charge (output without input or vice versa).
+
+### Period-end clearing failures
+
+Failing to clear all 261x-264x into 2650 at period end. Debit balance on 2650 at year-end should reclassify to 1650 (Momsfordran). Vilande accounts (2618/2628/2638/2648) never transferred cause under-reporting.
+
+### Import VAT errors
+
+Double-counting (paying Tullverket AND reporting in momsdeklaration). Reporting output VAT on imports (Ruta 60) without claiming input VAT (Ruta 48). Using old EU acquisition accounts instead of import-specific accounts.
+
+### Representation errors
+
+Deducting full VAT without 300 SEK cap. Confusing income tax deductibility (abolished 2017) with VAT deductibility (retained). Not separating avdragsgill/ej avdragsgill on correct accounts (6071 vs 6072).
+
+### Penalties
+
+| Violation | Consequence |
+|------|------|
+| Incorrect declaration | Skattetillägg: 20% of underpaid/overclaimed |
+| Period error within 4 months | Skattetillägg: 2% |
+| Period error in annual reporting | Skattetillägg: 5% |
+| Late filing (skattedeklaration) | Förseningsavgift: 625 SEK (1,250 after föreläggande) |
+| Late periodisk sammanställning | 1,250 SEK per report |
+| Failure to file (skönsbeskattning) | 20% skattetillägg on estimated amount |
+
+Voluntary correction before Skatteverket detection avoids skattetillägg. Both are not tax-deductible (BAS 6992).
+
+---
+
+## 10. Key Law References
+
+### Mervärdesskattelagen (2023:200)
+
+Replaced ML (1994:200) on 1 July 2023. Key terminology: "omsättning" → "leverans av varor/tillhandahållande av tjänster," "skattskyldig" → "beskattningsbar person/betalningsskyldig."
+
+| Chapter | Subject | Key sections |
+|------|------|------|
+| 5 kap. | Beskattningsbara transaktioner | §§22-25 (intra-EU) |
+| 6 kap. | Plats för transaktioner | §34 (B2B main rule), §35 (B2C) |
+| 7 kap. | Beskattningsgrundande händelse | §§4-6 |
+| 9 kap. | Skattesatser | §2 (25%), §§3-7 (12%), §§8-15 (6%) |
+| 10 kap. | Undantag | Healthcare, education, financial, property |
+| 12 kap. | Frivillig beskattning | Commercial property rental |
+| 13 kap. | Avdrag för ingående skatt | §6 (main), §18 (cars), §§24-25 (representation), §29 (mixed), §30 (95% rules) |
+| 15 kap. | Justering av avdrag | Jämkning; §10 (periods) |
+| 16 kap. | Betalningsskyldig | §§6-22 (reverse charge) |
+| 18 kap. | Liten årsomsättning | Small business (120,000 SEK from 2025) |
+| 22 kap. | OSS/IOSS | One Stop Shop |
+
+### Skatteförfarandelagen (2011:1244)
+
+| Chapter | Subject |
+|------|------|
+| 7 kap. | Registration (§1 who must register, §4 notification) |
+| 26 kap. | Skattedeklaration (§§10-11 periods, §13 voluntary changes/24mo lock-in, §§15-16 timing, §26 deadline 12th, §30 large entity 26th, §§33-33b annual) |
+| 35 kap. | Periodisk sammanställning (§9 deadline) |
+| 48 kap. | Förseningsavgift |
+| 49 kap. | Skattetillägg (§4: 20%, §11: 2% period errors) |
+| 62 kap. | Payment deadlines (§3) |
+
+### Key Skatteverket ställningstaganden
+
+- **Representation:** Dnr 131 519171-16/111 (2016-12-21, 300 SEK/schablon); Dnr 202 416536-17/111 (income tax)
+- **Mixed activities:** Dnr 8-2749853 (2024-02-05, post-HFD 2023 ref. 45)
+- **Jämkning:** Dnr 131 347924-07/111 (5% threshold); Dnr 8-2349336 (2023-05-12, property transfers)
+- **Import VAT:** Dnr 131 183789-16/111 (liability)
+
+### Key court rulings
+
+- **HFD 2023 ref. 45** - EU turnover method via direct effect for proportional deduction
+- **HFD 2025 not. 29** - Turnover method applies even with stadigvarande bostad
+- **C-787/18 (Sögård Fastigheter)** - Swedish jämkning transfer rules incompatible with EU law; reform underway (SOU 2026:24)
+
+### EU VAT Directive (2006/112/EC)
+
+Key articles: 44 (B2B services), 138 (intra-EU supply), 173-175 (proportional deduction), 176 (restriction stand-still), 184-192 (adjustment), 194 (optional domestic reverse charge). Implementing Regulation 282/2011 directly applicable per ML 1 kap. 4 §.

--- a/app/api/support/contact/route.ts
+++ b/app/api/support/contact/route.ts
@@ -3,6 +3,9 @@ import { NextResponse } from 'next/server'
 import { getEmailService } from '@/lib/email/service'
 import { SUPPORT_RECIPIENT_EMAIL } from '@/lib/support'
 import { requireCompanyId } from '@/lib/company/context'
+import { ensureInitialized } from '@/lib/init'
+
+ensureInitialized()
 
 function escapeHtml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')


### PR DESCRIPTION
## Summary
- Add Claude Code skills for Swedish payroll (arbetsgivaravgifter, AGI, tax tables, vacation pay, etc.) and VAT (moms) compliance reference
- Call `ensureInitialized()` in the support contact API route so the email extension is loaded

## Test plan
- [ ] Verify `/swedish-payroll` and `/swedish-vat` skills load correctly in Claude Code
- [ ] Verify support contact form sends email successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)