### PR TITLE
feat: enable company member invitations

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -74,6 +74,29 @@ export default function LoginPage() {
           return
         }
 
+        // Check for pending invite token
+        const bankIdCookieMatch = document.cookie.match(/gnubok-invite-token=([^;]+)/)
+        const bankIdInviteToken = bankIdCookieMatch?.[1]
+
+        if (bankIdInviteToken) {
+          try {
+            const res = await fetch('/api/team/accept', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ token: bankIdInviteToken }),
+            })
+
+            if (res.ok) {
+              document.cookie = 'gnubok-invite-token=; path=/; max-age=0'
+              window.location.href = '/'
+              return
+            }
+          } catch (err) {
+            console.error('[login] invite acceptance failed:', err)
+          }
+          document.cookie = 'gnubok-invite-token=; path=/; max-age=0'
+        }
+
         router.push('/')
         router.refresh()
       } catch (error) {
@@ -118,6 +141,30 @@ export default function LoginPage() {
       if (aal?.nextLevel === 'aal2' && aal?.currentLevel === 'aal1') {
         router.push('/mfa/verify')
         return
+      }
+
+      // Check for pending invite token
+      const cookieMatch = document.cookie.match(/gnubok-invite-token=([^;]+)/)
+      const inviteToken = cookieMatch?.[1]
+
+      if (inviteToken) {
+        try {
+          const res = await fetch('/api/team/accept', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ token: inviteToken }),
+          })
+
+          if (res.ok) {
+            document.cookie = 'gnubok-invite-token=; path=/; max-age=0'
+            window.location.href = '/'
+            return
+          }
+        } catch (err) {
+          console.error('[login] invite acceptance failed:', err)
+        }
+        // Clear cookie even on failure to avoid retrying stale tokens
+        document.cookie = 'gnubok-invite-token=; path=/; max-age=0'
       }
 
       router.push('/')

--- a/app/(auth)/mfa/verify/page.tsx
+++ b/app/(auth)/mfa/verify/page.tsx
@@ -100,6 +100,29 @@ export default function MfaVerifyPage() {
         return
       }
 
+      // Check for pending invite token
+      const cookieMatch = document.cookie.match(/gnubok-invite-token=([^;]+)/)
+      const inviteToken = cookieMatch?.[1]
+
+      if (inviteToken) {
+        try {
+          const res = await fetch('/api/team/accept', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ token: inviteToken }),
+          })
+
+          if (res.ok) {
+            document.cookie = 'gnubok-invite-token=; path=/; max-age=0'
+            window.location.href = '/'
+            return
+          }
+        } catch (err) {
+          console.error('[mfa/verify] invite acceptance failed:', err)
+        }
+        document.cookie = 'gnubok-invite-token=; path=/; max-age=0'
+      }
+
       router.push('/')
       router.refresh()
     } catch {

--- a/app/invite/[token]/page.tsx
+++ b/app/invite/[token]/page.tsx
@@ -52,6 +52,12 @@ export default function InvitePage() {
     router.push(`/register?invite=${encodeURIComponent(token)}`)
   }
 
+  const handleAcceptExistingUser = () => {
+    // Store invite token in cookie before redirecting to login
+    document.cookie = `gnubok-invite-token=${token}; path=/; max-age=3600; samesite=lax`
+    router.push('/login')
+  }
+
   if (isLoading) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-background">
@@ -124,24 +130,29 @@ export default function InvitePage() {
                 </div>
               </Card>
             ) : invite?.alreadyHasAccount ? (
-              <Card className="p-6">
-                <div className="flex items-start gap-3">
-                  <AlertCircle className="h-5 w-5 text-muted-foreground flex-shrink-0 mt-0.5" />
-                  <div>
-                    <p className="font-medium">E-postadressen har redan ett konto</p>
-                    <p className="text-sm text-muted-foreground mt-1">
-                      <strong>{invite.email}</strong> är redan registrerad på gnubok.
-                      Kontot måste tas bort innan du kan acceptera inbjudan.
-                    </p>
-                    <Link
-                      href="/login"
-                      className="text-sm text-primary hover:underline mt-3 inline-block"
-                    >
-                      Gå till inloggning
-                    </Link>
+              <div className="space-y-6">
+                <Card className="p-6">
+                  <div className="flex items-start gap-4">
+                    <div className="p-2.5 rounded-lg bg-muted/50">
+                      <Building2 className="h-5 w-5 text-muted-foreground" />
+                    </div>
+                    <div>
+                      <p className="font-medium">{invite.companyName}</p>
+                      <p className="text-sm text-muted-foreground mt-0.5">
+                        Du har bjudits in som medlem till detta företag.
+                      </p>
+                      <p className="text-sm text-muted-foreground mt-1">
+                        <strong>{invite.email}</strong> har redan ett konto på gnubok.
+                        Logga in för att gå med.
+                      </p>
+                    </div>
                   </div>
-                </div>
-              </Card>
+                </Card>
+
+                <Button size="lg" className="w-full" onClick={handleAcceptExistingUser}>
+                  Logga in och gå med
+                </Button>
+              </div>
             ) : invite ? (
               <div className="space-y-6">
                 <Card className="p-6">

--- a/app/invite/[token]/page.tsx
+++ b/app/invite/[token]/page.tsx
@@ -46,15 +46,17 @@ export default function InvitePage() {
     loadInvite()
   }, [token])
 
+  const secureCookieFlag = typeof window !== 'undefined' && window.location.protocol === 'https:' ? '; secure' : ''
+
   const handleAccept = () => {
     // Store invite token in cookie before redirecting to register
-    document.cookie = `gnubok-invite-token=${token}; path=/; max-age=3600; samesite=lax`
+    document.cookie = `gnubok-invite-token=${token}; path=/; max-age=3600; samesite=lax${secureCookieFlag}`
     router.push(`/register?invite=${encodeURIComponent(token)}`)
   }
 
   const handleAcceptExistingUser = () => {
     // Store invite token in cookie before redirecting to login
-    document.cookie = `gnubok-invite-token=${token}; path=/; max-age=3600; samesite=lax`
+    document.cookie = `gnubok-invite-token=${token}; path=/; max-age=3600; samesite=lax${secureCookieFlag}`
     router.push('/login')
   }
 

--- a/components/settings/CompanyMembersSection.tsx
+++ b/components/settings/CompanyMembersSection.tsx
@@ -158,14 +158,9 @@ export function CompanyMembersSection() {
 
   return (
     <div className="space-y-6">
-      {/* Invite form — disabled, coming soon */}
+      {/* Invite form */}
       {canInvite && (
-        <Card className="relative overflow-hidden">
-          <div className="absolute inset-0 bg-background/60 backdrop-blur-[1px] z-10 flex items-center justify-center">
-            <Badge variant="secondary" className="text-xs font-medium">
-              Kommer snart
-            </Badge>
-          </div>
+        <Card>
           <CardHeader>
             <CardTitle className="text-base">Bjud in till {company?.name}</CardTitle>
             <CardDescription>
@@ -173,21 +168,40 @@ export function CompanyMembersSection() {
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <div className="flex gap-3 pointer-events-none">
+            <form onSubmit={handleInvite} className="flex gap-3">
               <div className="flex-1">
                 <Label htmlFor="company-invite-email" className="sr-only">E-postadress</Label>
                 <Input
                   id="company-invite-email"
                   type="email"
                   placeholder="namn@example.com"
-                  disabled
+                  value={inviteEmail}
+                  onChange={(e) => setInviteEmail(e.target.value)}
+                  disabled={isSending}
+                  required
                 />
               </div>
-              <Button disabled>
-                <Plus className="h-4 w-4 mr-1.5" />
-                Bjud in
+              <Select value={inviteRole} onValueChange={setInviteRole}>
+                <SelectTrigger className="w-[140px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="viewer">Läsbehörighet</SelectItem>
+                  <SelectItem value="member">Medlem</SelectItem>
+                  <SelectItem value="admin">Admin</SelectItem>
+                </SelectContent>
+              </Select>
+              <Button type="submit" disabled={isSending || !inviteEmail.trim()}>
+                {isSending ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <>
+                    <Plus className="h-4 w-4 mr-1.5" />
+                    Bjud in
+                  </>
+                )}
               </Button>
-            </div>
+            </form>
           </CardContent>
         </Card>
       )}
@@ -253,8 +267,8 @@ export function CompanyMembersSection() {
         </CardContent>
       </Card>
 
-      {/* Pending invitations — hidden while invites are disabled */}
-      {false && invitations.length > 0 && (
+      {/* Pending invitations */}
+      {invitations.length > 0 && (
         <Card>
           <CardHeader>
             <CardTitle className="text-base">Väntande inbjudningar</CardTitle>


### PR DESCRIPTION
## Summary

- Activated the invite form in Settings > Företag (was hidden behind "Kommer snart" overlay) with email input, role selector, and submit button
- Unhid the pending invitations card so owners/admins can see and revoke outstanding invites
- Fixed the existing-user invite flow — previously showed a dead-end error, now redirects to login with the invite token
- Added invite token processing after both password and BankID login so existing users auto-join the company

All backend (API routes, token system, email templates, database/RLS) was already built — this change only activates the UI and fixes the existing-user acceptance path.

## Test plan

- [ ] Send invite from Settings > Företag — verify invite URL appears in browser console (dev) or email is sent (prod with Resend configured)
- [ ] Pending invitation appears in the UI with role badge and expiry date
- [ ] Revoke a pending invitation — verify it disappears
- [ ] New user: click invite link → register → auto-joins company
- [ ] Existing user: click invite link → sees "Logga in och gå med" → logs in → auto-joins company
- [ ] Verify role selector works (viewer/member/admin)
- [ ] Verify duplicate invite and already-member errors show correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)