### PR TITLE
fix: resolve INK2/NE entity_type from companies table fallback

### DIFF
--- a/app/(dashboard)/reports/page.tsx
+++ b/app/(dashboard)/reports/page.tsx
@@ -9,6 +9,7 @@ import { Badge } from '@/components/ui/badge'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
 import { Download, AlertCircle, ChevronDown, ChevronRight, ArrowRight } from 'lucide-react'
 import { AccountNumber } from '@/components/ui/account-number'
+import { useCompany } from '@/contexts/CompanyContext'
 import { NEDeclarationView } from '@/components/reports/NEDeclarationView'
 import { INK2DeclarationView } from '@/components/reports/INK2DeclarationView'
 import { BankReconciliationView } from '@/components/reports/BankReconciliationView'
@@ -48,8 +49,8 @@ export default function ReportsPage() {
   const [periods, setPeriods] = useState<FiscalPeriod[]>([])
   const [selectedPeriod, setSelectedPeriod] = useState('')
   const [activeTab, setActiveTab] = useState('trial-balance')
-  const [entityType, setEntityType] = useState<string | null>(null)
   const [isLoadingInit, setIsLoadingInit] = useState(true)
+  const { company } = useCompany()
 
   // Drill-down state: when navigating from a report to the GL for a specific account
   const [glAccountFilter, setGlAccountFilter] = useState<string | null>(null)
@@ -89,26 +90,14 @@ export default function ReportsPage() {
     }
   }
 
-  async function fetchEntityType() {
-    try {
-      const res = await fetch('/api/settings')
-      const { data } = await res.json()
-      if (data?.entity_type) {
-        setEntityType(data.entity_type)
-      }
-    } catch {
-      // Ignore - entity type is optional for tab visibility
-    }
-  }
-
   useEffect(() => {
-    Promise.all([fetchPeriods(), fetchEntityType()]).finally(() => {
+    fetchPeriods().finally(() => {
       setIsLoadingInit(false)
     })
   }, [])
 
-  const isEnskildFirma = entityType === 'enskild_firma'
-  const isAktiebolag = entityType === 'aktiebolag'
+  const isEnskildFirma = company?.entity_type === 'enskild_firma'
+  const isAktiebolag = company?.entity_type === 'aktiebolag'
 
   return (
     <div className="space-y-6">

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -27,6 +27,7 @@ export async function GET() {
   }
 
   // Fall back to companies.entity_type if company_settings.entity_type is null
+  let responseData = data
   if (data && !data.entity_type) {
     const { data: company } = await supabase
       .from('companies')
@@ -34,11 +35,11 @@ export async function GET() {
       .eq('id', companyId)
       .single()
     if (company?.entity_type) {
-      data = { ...data, entity_type: company.entity_type }
+      responseData = { ...data, entity_type: company.entity_type }
     }
   }
 
-  return NextResponse.json({ data })
+  return NextResponse.json({ data: responseData })
 }
 
 export async function PUT(request: Request) {

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -26,6 +26,18 @@ export async function GET() {
     return NextResponse.json({ error: error.message }, { status: 500 })
   }
 
+  // Fall back to companies.entity_type if company_settings.entity_type is null
+  if (data && !data.entity_type) {
+    const { data: company } = await supabase
+      .from('companies')
+      .select('entity_type')
+      .eq('id', companyId)
+      .single()
+    if (company?.entity_type) {
+      data.entity_type = company.entity_type
+    }
+  }
+
   return NextResponse.json({ data })
 }
 

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -34,7 +34,7 @@ export async function GET() {
       .eq('id', companyId)
       .single()
     if (company?.entity_type) {
-      data.entity_type = company.entity_type
+      data = { ...data, entity_type: company.entity_type }
     }
   }
 

--- a/lib/reports/ink2/ink2-engine.ts
+++ b/lib/reports/ink2/ink2-engine.ts
@@ -717,11 +717,12 @@ export async function generateINK2Declaration(
   // Resolve entity_type: prefer company_settings, fall back to companies table (NOT NULL, always reliable)
   let entityType = settings?.entity_type
   if (!entityType) {
-    const { data: company } = await supabase
+    const { data: company, error: companyError } = await supabase
       .from('companies')
       .select('entity_type')
       .eq('id', companyId)
       .single()
+    if (companyError) throw new Error(`Failed to resolve entity type: ${companyError.message}`)
     entityType = company?.entity_type
   }
 

--- a/lib/reports/ink2/ink2-engine.ts
+++ b/lib/reports/ink2/ink2-engine.ts
@@ -714,8 +714,18 @@ export async function generateINK2Declaration(
     .eq('company_id', companyId)
     .single()
 
-  // Validate entity type
-  if (settings?.entity_type !== 'aktiebolag') {
+  // Resolve entity_type: prefer company_settings, fall back to companies table (NOT NULL, always reliable)
+  let entityType = settings?.entity_type
+  if (!entityType) {
+    const { data: company } = await supabase
+      .from('companies')
+      .select('entity_type')
+      .eq('id', companyId)
+      .single()
+    entityType = company?.entity_type
+  }
+
+  if (entityType !== 'aktiebolag') {
     throw new Error('INK2 declaration is only for aktiebolag (limited company)')
   }
 

--- a/lib/reports/ne-bilaga/ne-engine.ts
+++ b/lib/reports/ne-bilaga/ne-engine.ts
@@ -182,11 +182,12 @@ export async function generateNEDeclaration(
   // Resolve entity_type: prefer company_settings, fall back to companies table (NOT NULL, always reliable)
   let entityType = settings?.entity_type
   if (!entityType) {
-    const { data: company } = await supabase
+    const { data: company, error: companyError } = await supabase
       .from('companies')
       .select('entity_type')
       .eq('id', companyId)
       .single()
+    if (companyError) throw new Error(`Failed to resolve entity type: ${companyError.message}`)
     entityType = company?.entity_type
   }
 

--- a/lib/reports/ne-bilaga/ne-engine.ts
+++ b/lib/reports/ne-bilaga/ne-engine.ts
@@ -179,8 +179,18 @@ export async function generateNEDeclaration(
     .eq('company_id', companyId)
     .single()
 
-  // Check if it's enskild firma
-  if (settings?.entity_type !== 'enskild_firma') {
+  // Resolve entity_type: prefer company_settings, fall back to companies table (NOT NULL, always reliable)
+  let entityType = settings?.entity_type
+  if (!entityType) {
+    const { data: company } = await supabase
+      .from('companies')
+      .select('entity_type')
+      .eq('id', companyId)
+      .single()
+    entityType = company?.entity_type
+  }
+
+  if (entityType !== 'enskild_firma') {
     throw new Error('NE declaration is only for enskild firma (sole proprietorship)')
   }
 


### PR DESCRIPTION
## Summary

Fixes #193 — user with aktiebolag gets "INK2 declaration is only for aktiebolag" because `company_settings.entity_type` is null.

- **INK2 & NE-bilaga engines**: fall back to `companies.entity_type` (NOT NULL, always set) when `company_settings.entity_type` is null
- **Reports page**: use `useCompany()` context (from `companies` table) instead of fetching entity_type from `/api/settings`
- **Settings API**: defensive fallback so other consumers also get a resolved entity_type

## Test plan

- [ ] Verify aktiebolag company with null `company_settings.entity_type` can generate INK2
- [ ] Verify reports page shows correct INK2/NE-bilaga tab
- [ ] Verify normal companies with populated settings still work
- [ ] All existing tests pass (86/86 in INK2 + NE suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)