### PR TITLE
fix: add missing default_voucher_series column to company_settings

### DIFF
--- a/supabase/migrations/20260418150000_company_settings_default_voucher_series.sql
+++ b/supabase/migrations/20260418150000_company_settings_default_voucher_series.sql
@@ -14,6 +14,20 @@
 ALTER TABLE public.company_settings
   ADD COLUMN IF NOT EXISTS default_voucher_series text NOT NULL DEFAULT 'A';
 
+-- ADD COLUMN IF NOT EXISTS silently skips the whole column definition
+-- (including NOT NULL) when the column already exists. Re-apply the
+-- constraint explicitly so environments that received the column
+-- out-of-band still end up with the same schema.
+ALTER TABLE public.company_settings
+  ALTER COLUMN default_voucher_series SET DEFAULT 'A';
+
+UPDATE public.company_settings
+  SET default_voucher_series = 'A'
+  WHERE default_voucher_series IS NULL;
+
+ALTER TABLE public.company_settings
+  ALTER COLUMN default_voucher_series SET NOT NULL;
+
 -- Match the Zod validation in lib/api/schemas.ts so DB and app stay in sync.
 ALTER TABLE public.company_settings
   DROP CONSTRAINT IF EXISTS company_settings_default_voucher_series_check;

--- a/supabase/migrations/20260418150000_company_settings_default_voucher_series.sql
+++ b/supabase/migrations/20260418150000_company_settings_default_voucher_series.sql
@@ -1,0 +1,27 @@
+-- Add default_voucher_series to company_settings.
+--
+-- The frontend (/settings/bookkeeping) and TypeScript types have referenced
+-- this column for a while, but no migration ever added it, so saving the form
+-- failed with: "Could not find the 'default_voucher_series' column of
+-- 'company_settings' in the schema cache".
+--
+-- The column stores the per-company default voucher series (A–Z) that is
+-- pre-selected when booking manual journal entries. The actual sequence
+-- counters live in public.voucher_sequences, keyed on (user_id,
+-- fiscal_period_id, voucher_series) — this setting only controls the UI
+-- default.
+
+ALTER TABLE public.company_settings
+  ADD COLUMN IF NOT EXISTS default_voucher_series text NOT NULL DEFAULT 'A';
+
+-- Match the Zod validation in lib/api/schemas.ts so DB and app stay in sync.
+ALTER TABLE public.company_settings
+  DROP CONSTRAINT IF EXISTS company_settings_default_voucher_series_check;
+
+ALTER TABLE public.company_settings
+  ADD CONSTRAINT company_settings_default_voucher_series_check
+  CHECK (default_voucher_series ~ '^[A-Z]$');
+
+-- Reload PostgREST schema cache so the column becomes visible to the API
+-- immediately, without waiting for the next automatic reload.
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
- Frontend (`/settings/bookkeeping`), `types/index.ts`, and `lib/api/schemas.ts` have all referenced `company_settings.default_voucher_series`, but no migration ever added it. Saving the "Standardserie för verifikationer" setting failed with a PostgREST schema-cache error.
- Adds the column as `text NOT NULL DEFAULT 'A'` with a CHECK constraint mirroring the existing Zod validation (`^[A-Z]\$`).
- Ends with `NOTIFY pgrst, 'reload schema'` per CLAUDE.md rules.

## Why this slipped through
The column was referenced in the type, schema, and form without a matching DDL change. Every hosted user who opened the Bookkeeping settings page and hit Save would have hit this.

## Production state
Migration **already applied** to prod (`pwxtzglxptnnvjrpixpg`) to unblock a reporting user mid-session. This PR is the code-of-record catch-up — the file just needs to land in `supabase/migrations/` so other environments (self-hosted, preview branches, fresh boot) pick it up.

## Test plan
- [ ] Open `/settings/bookkeeping`, change the Serie dropdown from A to (e.g.) B, click Save — confirm it saves without error.
- [ ] Reload the page — confirm the new value persists.
- [ ] Try writing `'AA'` or `'1'` via direct SQL — confirm the CHECK constraint rejects it.
- [ ] Fresh Supabase boot (or branch) applies this migration cleanly without needing `IF NOT EXISTS` escapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)