### PR TITLE
fix: show Ersätt befintlig import button for duplicate-file SIE uploads

### DIFF
--- a/app/(dashboard)/import/page.tsx
+++ b/app/(dashboard)/import/page.tsx
@@ -334,7 +334,7 @@ function SIEImportWizard() {
   const [errorType, setErrorType] = useState<'duplicate' | 'duplicate_period' | 'validation' | 'parse' | undefined>()
   const [validationErrors, setValidationErrors] = useState<string[]>([])
   const [validationWarnings, setValidationWarnings] = useState<string[]>([])
-  const [duplicatePeriodImportId, setDuplicatePeriodImportId] = useState<string | null>(null)
+  const [duplicateImportId, setDuplicateImportId] = useState<string | null>(null)
   const [isReplacing, setIsReplacing] = useState(false)
 
   const [file, setFile] = useState<File | null>(null)
@@ -380,8 +380,8 @@ function SIEImportWizard() {
         if (type === 'duplicate' || type === 'duplicate_period') {
           setErrorType(type)
           setError(data.message)
-          if (type === 'duplicate_period' && data.importId) {
-            setDuplicatePeriodImportId(data.importId)
+          if (data.importId) {
+            setDuplicateImportId(data.importId)
           }
           toast({ title: type === 'duplicate' ? 'Filen har redan importerats' : 'Överlappande räkenskapsår', description: data.message, variant: 'destructive' })
         } else if (type === 'validation') {
@@ -459,7 +459,7 @@ function SIEImportWizard() {
       // Clear error state and re-trigger the file upload
       setError(null)
       setErrorType(undefined)
-      setDuplicatePeriodImportId(null)
+      setDuplicateImportId(null)
 
       // Small delay so the user sees the success toast before re-upload starts
       await new Promise(resolve => setTimeout(resolve, 500))
@@ -618,7 +618,7 @@ function SIEImportWizard() {
   const handleNewImport = () => {
     setStep('upload'); setFile(null); setParsed(null); setMappings([])
     setPreview(null); setIssues([]); setImportResult(null); setError(null); setErrorType(undefined)
-    setValidationErrors([]); setValidationWarnings([]); setDuplicatePeriodImportId(null)
+    setValidationErrors([]); setValidationWarnings([]); setDuplicateImportId(null)
     setSieAccounts([]); setIsCreatingAccounts(false)
   }
 
@@ -645,7 +645,7 @@ function SIEImportWizard() {
         </CardContent>
       </Card>
 
-      {step === 'upload' && <SIEUploadStep onFileSelect={handleFileSelect} isLoading={isLoading} error={error} errorType={errorType} validationErrors={validationErrors} validationWarnings={validationWarnings} duplicatePeriodImportId={duplicatePeriodImportId} onReplace={handleReplace} isReplacing={isReplacing} />}
+      {step === 'upload' && <SIEUploadStep onFileSelect={handleFileSelect} isLoading={isLoading} error={error} errorType={errorType} validationErrors={validationErrors} validationWarnings={validationWarnings} duplicateImportId={duplicateImportId} onReplace={handleReplace} isReplacing={isReplacing} />}
       {step === 'preview' && preview && (
         <SIEPreviewStep preview={preview} issues={issues} missingAccounts={missingAccounts}
           onCreateAccounts={handleCreateAccounts} isCreatingAccounts={isCreatingAccounts}

--- a/components/import/SIEUploadStep.tsx
+++ b/components/import/SIEUploadStep.tsx
@@ -20,12 +20,12 @@ interface SIEUploadStepProps {
   errorType?: 'duplicate' | 'duplicate_period' | 'validation' | 'parse'
   validationErrors?: string[]
   validationWarnings?: string[]
-  duplicatePeriodImportId?: string | null
+  duplicateImportId?: string | null
   onReplace?: (importId: string) => Promise<void>
   isReplacing?: boolean
 }
 
-export default function SIEUploadStep({ onFileSelect, isLoading, error, errorType, validationErrors, validationWarnings, duplicatePeriodImportId, onReplace, isReplacing }: SIEUploadStepProps) {
+export default function SIEUploadStep({ onFileSelect, isLoading, error, errorType, validationErrors, validationWarnings, duplicateImportId, onReplace, isReplacing }: SIEUploadStepProps) {
   const [isDragging, setIsDragging] = useState(false)
   const [selectedFile, setSelectedFile] = useState<File | null>(null)
   const [loadingPhase, setLoadingPhase] = useState(0)
@@ -192,13 +192,10 @@ export default function SIEUploadStep({ onFileSelect, isLoading, error, errorTyp
 
                   {/* Actionable guidance */}
                   <div className="text-sm text-muted-foreground pt-1 border-t border-border/50 mt-2">
-                    {errorType === 'duplicate' && (
-                      <p>Om du vill importera om filen, ta först bort den tidigare importen under Bokföring.</p>
-                    )}
-                    {errorType === 'duplicate_period' && (
+                    {(errorType === 'duplicate' || errorType === 'duplicate_period') && (
                       <div className="space-y-2">
                         <p>Den befintliga importens verifikationer kommer att makuleras (status ändras till &quot;makulerad&quot;). De finns kvar som spårbar historik.</p>
-                        {duplicatePeriodImportId && onReplace && (
+                        {duplicateImportId && onReplace && (
                           <Button
                             variant="outline"
                             size="sm"
@@ -206,7 +203,7 @@ export default function SIEUploadStep({ onFileSelect, isLoading, error, errorTyp
                             disabled={isReplacing}
                             onClick={(e) => {
                               e.stopPropagation()
-                              onReplace(duplicatePeriodImportId)
+                              onReplace(duplicateImportId)
                             }}
                           >
                             {isReplacing ? (


### PR DESCRIPTION
## Summary
- The duplicate (file-hash) error path in `/import` returned an `importId` from the API, but the UI only captured it for `duplicate_period`. Users who re-uploaded the same SIE file saw a misleading "ta först bort den tidigare importen under Bokföring" message with no button and no such UI anywhere in the app.
- Renames `duplicatePeriodImportId` → `duplicateImportId` and shows the existing **Ersätt befintlig import** button for both duplicate cases.
- Backend untouched. Same `replaceSIEImport` path, same BFL 5:5 / BFNAR 2013:2 audit-trail guarantees (entries flip to `cancelled`, never deleted; `sie_imports` flips to `replaced` with timestamp).

## Why
Real user hit this today mid-migration (importing 9 years of history). They had manually deleted the 2026 drafts, then couldn't re-upload because the duplicate-hash check blocked them and the suggested remediation pointed at a UI that doesn't exist. Unblocked them by running `replace_sie_import` manually — this PR makes the UI self-service.

## Compliance impact
None — only the UI discoverability of an existing feature changed. The old copy arguably described a non-compliant action ("delete prior import"); the new copy describes what actually happens (makulering with audit trail).

## Test plan
- [ ] Upload a SIE file that's already been imported (same hash). Confirm **Ersätt befintlig import** appears in the error card.
- [ ] Click the button; confirm prior import is marked `replaced` in `sie_imports`, posted entries flip to `cancelled`, and re-upload proceeds.
- [ ] Upload a SIE file for an overlapping fiscal year (different hash). Confirm the same button still works (regression).
- [ ] Confirm the button's replace call fails gracefully if the prior period is closed/locked (existing `replaceSIEImport` guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)