### PR TITLE
feat: dynamic voucher series dropdown in SIE import

### DIFF
--- a/components/import/ImportReviewStep.tsx
+++ b/components/import/ImportReviewStep.tsx
@@ -63,17 +63,21 @@ export default function ImportReviewStep({
   })
   const [defaultSeries, setDefaultSeries] = useState<string | null>(null)
   const [existingSeries, setExistingSeries] = useState<Set<string>>(new Set())
+  const [seriesLoaded, setSeriesLoaded] = useState(false)
   const [elapsed, setElapsed] = useState(0)
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
-  const seriesInitializedRef = useRef(false)
 
   useEffect(() => {
     if (!company?.id) return
+    setSeriesLoaded(false)
     const supabase = createClient()
 
     let cancelled = false
     ;(async () => {
-      const [{ data: settingsData }, { data: sequencesData }] = await Promise.all([
+      const [
+        { data: settingsData, error: settingsError },
+        { data: sequencesData, error: sequencesError },
+      ] = await Promise.all([
         supabase
           .from('company_settings')
           .select('default_voucher_series')
@@ -87,17 +91,23 @@ export default function ImportReviewStep({
 
       if (cancelled) return
 
+      // PGRST116 = no rows returned from .single(); expected when settings not yet created.
+      if (settingsError && settingsError.code !== 'PGRST116') {
+        console.error('Failed to load company settings for voucher series', settingsError)
+      }
+      if (sequencesError) {
+        console.error('Failed to load voucher sequences', sequencesError)
+      }
+
       const companyDefault = settingsData?.default_voucher_series || null
       const sequences = new Set<string>((sequencesData || []).map((row) => row.voucher_series))
 
       setDefaultSeries(companyDefault)
       setExistingSeries(sequences)
 
-      if (!seriesInitializedRef.current) {
-        seriesInitializedRef.current = true
-        const initial = companyDefault || (sequences.has('B') ? 'B' : Array.from(sequences).sort()[0]) || 'A'
-        setOptions((prev) => ({ ...prev, voucherSeries: initial }))
-      }
+      const initial = companyDefault || (sequences.has('B') ? 'B' : Array.from(sequences).sort()[0]) || 'A'
+      setOptions((prev) => ({ ...prev, voucherSeries: initial }))
+      setSeriesLoaded(true)
     })()
 
     return () => {
@@ -286,6 +296,7 @@ export default function ImportReviewStep({
               <Select
                 value={options.voucherSeries}
                 onValueChange={(value) => updateOption('voucherSeries', value)}
+                disabled={!seriesLoaded}
               >
                 <SelectTrigger id="voucher-series" className="w-48">
                   <SelectValue />

--- a/components/import/ImportReviewStep.tsx
+++ b/components/import/ImportReviewStep.tsx
@@ -25,7 +25,11 @@ import {
 } from 'lucide-react'
 import { useUnsavedChanges } from '@/lib/hooks/use-unsaved-changes'
 import { useCanWrite } from '@/lib/hooks/use-can-write'
+import { createClient } from '@/lib/supabase/client'
+import { useCompany } from '@/contexts/CompanyContext'
 import type { ImportPreview, AccountMapping } from '@/lib/import/types'
+
+const SERIES_LETTERS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('')
 
 interface ImportReviewStepProps {
   preview: ImportPreview
@@ -50,14 +54,56 @@ export default function ImportReviewStep({
   isLoading,
 }: ImportReviewStepProps) {
   const { canWrite } = useCanWrite()
+  const { company } = useCompany()
   const [options, setOptions] = useState<ImportExecuteOptions>({
     createFiscalPeriod: true,
     importOpeningBalances: true,
     importTransactions: true,
     voucherSeries: 'B',
   })
+  const [defaultSeries, setDefaultSeries] = useState<string | null>(null)
+  const [existingSeries, setExistingSeries] = useState<Set<string>>(new Set())
   const [elapsed, setElapsed] = useState(0)
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const seriesInitializedRef = useRef(false)
+
+  useEffect(() => {
+    if (!company?.id) return
+    const supabase = createClient()
+
+    let cancelled = false
+    ;(async () => {
+      const [{ data: settingsData }, { data: sequencesData }] = await Promise.all([
+        supabase
+          .from('company_settings')
+          .select('default_voucher_series')
+          .eq('company_id', company.id)
+          .single(),
+        supabase
+          .from('voucher_sequences')
+          .select('voucher_series')
+          .eq('company_id', company.id),
+      ])
+
+      if (cancelled) return
+
+      const companyDefault = settingsData?.default_voucher_series || null
+      const sequences = new Set<string>((sequencesData || []).map((row) => row.voucher_series))
+
+      setDefaultSeries(companyDefault)
+      setExistingSeries(sequences)
+
+      if (!seriesInitializedRef.current) {
+        seriesInitializedRef.current = true
+        const initial = companyDefault || (sequences.has('B') ? 'B' : Array.from(sequences).sort()[0]) || 'A'
+        setOptions((prev) => ({ ...prev, voucherSeries: initial }))
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [company?.id])
 
   // Block browser close/refresh during import
   useUnsavedChanges(isLoading)
@@ -245,10 +291,20 @@ export default function ImportReviewStep({
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="A">A - Huvudserie</SelectItem>
-                  <SelectItem value="B">B - Import</SelectItem>
-                  <SelectItem value="C">C - Korrigeringar</SelectItem>
-                  <SelectItem value="I">I - Import (alternativ)</SelectItem>
+                  {SERIES_LETTERS.map((letter) => {
+                    const isDefault = defaultSeries === letter
+                    const isExisting = existingSeries.has(letter)
+                    const suffix = isDefault
+                      ? ' — standard'
+                      : isExisting
+                        ? ' — används redan'
+                        : ''
+                    return (
+                      <SelectItem key={letter} value={letter}>
+                        {`Serie ${letter}${suffix}`}
+                      </SelectItem>
+                    )
+                  })}
                 </SelectContent>
               </Select>
               <p className="text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary
- Replace the hardcoded A/B/C/I voucher series list in the SIE import review step with a dynamic A–Z picker driven by the company's own data.
- Fetch `company_settings.default_voucher_series` and existing `voucher_sequences` once per company; label the default series as **standard** and any already-in-use series as **används redan**.
- Preselect the company default, falling back to B, then the first existing series alphabetically, then A.

## Test plan
- [ ] Open SIE import on a company with a non-standard default series (e.g. `A`) and verify it is preselected and labeled "standard".
- [ ] Open SIE import on a company with multiple existing series and verify each is labeled "används redan".
- [ ] Verify a company with no settings and no sequences falls back to `A` without crashing.
- [ ] Run through a full SIE import using a newly chosen series (e.g. `E`) and confirm the vouchers land on that series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)