### PR TITLE
fix: let TIC lookup run during onboarding + tolerate lowercase TIC status

### DIFF
--- a/app/api/extensions/ext/[...path]/route.ts
+++ b/app/api/extensions/ext/[...path]/route.ts
@@ -118,8 +118,6 @@ async function handleRequest(
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const companyId = await requireCompanyId(supabase, user.id)
-
   // If path params were extracted, create a new Request with them as search params
   let handlerRequest = request
   if (Object.keys(extractedParams).length > 0) {
@@ -137,6 +135,15 @@ async function handleRequest(
       duplex: 'half',
     })
   }
+
+  // Routes that are authenticated but run before a company exists (TIC
+  // /lookup during onboarding, for example) opt out of company resolution.
+  // Dispatch without a context — handlers that opt in must not rely on ctx.
+  if (matchedRoute.skipCompanyContext) {
+    return matchedRoute.handler(handlerRequest)
+  }
+
+  const companyId = await requireCompanyId(supabase, user.id)
 
   // Build context and dispatch
   const ctx = createExtensionContext(supabase, user.id, companyId, extensionId)

--- a/app/api/extensions/ext/[...path]/route.ts
+++ b/app/api/extensions/ext/[...path]/route.ts
@@ -89,6 +89,21 @@ async function handleRequest(
     return NextResponse.json({ error: 'Route not found' }, { status: 404 })
   }
 
+  // Config sanity check: these flags are orthogonal and the combination is
+  // nonsensical. `skipAuth` already implies no company resolution, so adding
+  // `skipCompanyContext: true` is at best redundant — and if a maintainer
+  // intended "auth required, no company" but also wrote `skipAuth: true`,
+  // the auth requirement would be silently dropped (skipAuth fires first
+  // below). Fail loudly instead of masking the mistake.
+  if (matchedRoute.skipAuth && matchedRoute.skipCompanyContext) {
+    console.error('[extension-dispatcher] route misconfigured: skipAuth + skipCompanyContext are mutually exclusive', {
+      extensionId,
+      routePath,
+      method,
+    })
+    return NextResponse.json({ error: 'Route misconfigured' }, { status: 500 })
+  }
+
   // For skipAuth routes (e.g. OAuth callbacks from external providers),
   // skip user auth, toggle check, and AI consent — dispatch immediately
   if (matchedRoute.skipAuth) {

--- a/extensions/general/tic/index.ts
+++ b/extensions/general/tic/index.ts
@@ -49,11 +49,21 @@ async function fetchAndStoreEnrichment(
       hasSecureUrl: !!enrichment.secureUrl,
     })
 
-    // Accept both fully and partially completed runs — if the tenant only has
-    // SPAR enabled (not CompanyRoles), we still want the address data.
-    const usable = (enrichment.status === 'Completed' || enrichment.status === 'PartiallyCompleted')
-      && enrichment.secureUrl
-    if (!usable) return
+    // Case-insensitive status comparison: TIC has been observed returning
+    // lowercase values ('completed', 'failed') in addition to the docs' canonical
+    // capitalized form. Accept both fully and partially completed runs — if the
+    // tenant only has SPAR enabled (not CompanyRoles) we still want the address.
+    const statusLower = String(enrichment.status ?? '').toLowerCase()
+    const isCompleted = statusLower === 'completed' || statusLower === 'partiallycompleted'
+    const usable = isCompleted && enrichment.secureUrl
+    if (!usable) {
+      // Log the full response shape (sans secureUrl — time-limited token)
+      // so we can diagnose why a real-user enrichment comes back non-usable.
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { secureUrl: _omit, ...responseDiagnostic } = enrichment
+      log.warn('enrichment not usable — inspect response for diagnostic fields', responseDiagnostic)
+      return
+    }
 
     const enrichmentData = await fetchEnrichmentData(enrichment.secureUrl)
 
@@ -193,6 +203,10 @@ export const ticExtension: Extension = {
     {
       method: 'GET',
       path: '/lookup',
+      // Used during onboarding (Step2CompanyDetails debounced lookup + the
+      // BankID picker) — user is authenticated but does not yet have a
+      // company. Must not require a company context.
+      skipCompanyContext: true,
       handler: async (request: Request, ctx?) => {
         const log = ctx?.log ?? console
         const url = new URL(request.url)
@@ -305,6 +319,9 @@ export const ticExtension: Extension = {
     {
       method: 'GET',
       path: '/profile',
+      // Used during onboarding to render richer company profile details —
+      // user is authenticated but may not yet have a company. See /lookup.
+      skipCompanyContext: true,
       handler: async (request: Request, ctx?) => {
         const log = ctx?.log ?? console
         const url = new URL(request.url)

--- a/lib/extensions/types.ts
+++ b/lib/extensions/types.ts
@@ -68,6 +68,14 @@ export interface ApiRouteDefinition {
   path: string
   /** Skip auth check for this route (e.g. OAuth callbacks from external providers) */
   skipAuth?: boolean
+  /**
+   * Require auth but NOT a resolved company context. Use for routes that
+   * legitimately run during onboarding (before the user has a company) —
+   * e.g. TIC /lookup used by Step2CompanyDetails to fetch company info
+   * while the user types their org number. Handler is called without a
+   * ctx argument; handlers that opt in must tolerate a missing context.
+   */
+  skipCompanyContext?: boolean
   handler: (request: Request, ctx?: ExtensionContext) => Promise<Response>
 }
 

--- a/lib/extensions/types.ts
+++ b/lib/extensions/types.ts
@@ -62,7 +62,14 @@ export interface RouteDefinition {
   label: string
 }
 
-/** An API route exposed by an extension */
+/**
+ * An API route exposed by an extension.
+ *
+ * Auth/context modes (mutually exclusive — combining throws at dispatch time):
+ *   - default: requires auth AND a resolved company; ctx is passed to the handler
+ *   - `skipAuth: true`: no auth, no ctx (e.g. OAuth callbacks)
+ *   - `skipCompanyContext: true`: auth required, no ctx (pre-onboarding routes)
+ */
 export interface ApiRouteDefinition {
   method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH'
   path: string
@@ -74,6 +81,9 @@ export interface ApiRouteDefinition {
    * e.g. TIC /lookup used by Step2CompanyDetails to fetch company info
    * while the user types their org number. Handler is called without a
    * ctx argument; handlers that opt in must tolerate a missing context.
+   *
+   * Must NOT be combined with `skipAuth: true` — the dispatcher treats
+   * that as a misconfiguration and returns 500.
    */
   skipCompanyContext?: boolean
   handler: (request: Request, ctx?: ExtensionContext) => Promise<Response>


### PR DESCRIPTION
## Summary

Two bugs surfaced in live-prod testing of the BankID company picker (merged in #344):

### 1. `/api/extensions/ext/tic/lookup` 500s during onboarding

The extension dispatcher (\`app/api/extensions/ext/[...path]/route.ts:121\`) called \`requireCompanyId\` for **every** non-skipAuth route. \`Step2CompanyDetails\` triggers a debounced fetch to \`/api/extensions/ext/tic/lookup\` as the user types their org number — before they have a company. The call threw \"No company context\" and 500'd, surfacing in prod logs as:

\`\`\`
Error: No company context
    at r (.next/server/chunks/[root-of-the-server]__...)
\`\`\`

**Fix:** added a \`skipCompanyContext?: boolean\` flag to \`ApiRouteDefinition\`. Routes that opt in are dispatched without a ctx argument. \`/lookup\` and \`/profile\` on the TIC extension are marked — neither uses the context, so no downstream changes were needed.

### 2. TIC enrichment silently rejected on lowercase status values

Real-prod log for a confirmed SPAR+CompanyRoles user showed:

\`\`\`
status: 'failed'        ← lowercase
requestedTypes: [ 'spar', 'companyRoles' ]   ← lowercase
\`\`\`

My guard was \`enrichment.status === 'Completed'\` — strict case. If TIC started returning lowercase consistently, even a legitimately successful enrichment would have been silently rejected. Now comparing case-insensitively.

**Also improved diagnostics:** on any non-usable enrichment, log the full response shape (minus the time-limited \`secureUrl\` token) so the next failure is debuggable. This will tell us whether \`Failed\` responses carry an \`error\` or \`message\` field we should surface.

## Test plan

- [ ] In preview: BankID signup with a real personnummer → type an org number in Step 2 → confirm the TIC lookup hits successfully (no more 500).
- [ ] Same flow, verify the auto-populated company name / address from \`/lookup\`.
- [ ] Re-trigger enrichment in Vercel logs — if status is lowercase but succeeds, verify the picker now shows TIC companies instead of falling through to /onboarding.
- [ ] If enrichment still returns \`failed\`, the new diagnostic log should reveal whatever extra fields TIC is setting (likely a \`message\` or similar); share those logs and we can iterate.

## Risk

Low — the \`skipCompanyContext\` flag is opt-in; existing extension routes are unchanged. The status comparison is strictly looser (accepts both cases) so no previously-successful enrichment becomes unusable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)