### PR TITLE
chore: drop dead SPAR-reading code

### DIFF
--- a/components/dashboard/WelcomeOnboarding.tsx
+++ b/components/dashboard/WelcomeOnboarding.tsx
@@ -1,12 +1,11 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { createClient } from '@/lib/supabase/client'
 import { createCompanyFromOnboarding } from '@/lib/company/actions'
 import { computeFiscalPeriod } from '@/lib/company/compute-fiscal-period'
 import { useToast } from '@/components/ui/use-toast'
-import { Loader2, Building2 } from 'lucide-react'
+import { Building2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { ENABLED_EXTENSION_IDS } from '@/lib/extensions/_generated/enabled-extensions'
 import type { CompanyLookupResult } from '@/lib/company-lookup/types'
@@ -61,10 +60,8 @@ export default function WelcomeOnboarding({
 }: WelcomeOnboardingProps) {
   const router = useRouter()
   const { toast } = useToast()
-  const supabase = createClient()
 
   const [started, setStarted] = useState(skipWelcome ?? false)
-  const [isLoading, setIsLoading] = useState(true)
   const [isSaving, setIsSaving] = useState(false)
   const [currentStep, setCurrentStep] = useState(1)
   const [settings, setSettings] = useState<Partial<CompanySettings>>(
@@ -77,46 +74,6 @@ export default function WelcomeOnboarding({
 
   const hour = new Date().getHours()
   const greeting = hour < 5 ? 'God natt' : hour < 10 ? 'Godmorgon' : hour < 14 ? 'Hej' : hour < 18 ? 'God eftermiddag' : 'God kväll'
-
-  // Pre-fill the user's folkbokföringsadress from BankID/SPAR enrichment when
-  // available. The row is persisted (not consumed here) so /select-company and
-  // repeat /onboarding visits still see it; it's deleted only once a company
-  // is successfully created (see createCompanyFromOnboarding).
-  useEffect(() => {
-    async function loadSparAddress() {
-      const { data: { user } } = await supabase.auth.getUser()
-      if (!user) {
-        router.push('/login')
-        return
-      }
-
-      try {
-        const { data: enrichmentRow } = await supabase
-          .from('extension_data')
-          .select('value')
-          .eq('user_id', user.id)
-          .eq('extension_id', 'tic')
-          .eq('key', 'bankid_enrichment')
-          .maybeSingle()
-
-        const spar = (enrichmentRow?.value as { spar?: Record<string, string> } | null)?.spar
-        if (spar) {
-          setSettings((prev) => ({
-            ...prev,
-            address_line1: spar.Folkbokforingsadress_SvenskAdress_Utdelningsadress1 || prev.address_line1,
-            postal_code: spar.Folkbokforingsadress_SvenskAdress_PostNr || prev.postal_code,
-            city: spar.Folkbokforingsadress_SvenskAdress_Postort || prev.city,
-          }))
-        }
-      } catch (err) {
-        console.warn(LOG, 'enrichment loading failed (non-blocking)', err)
-      }
-
-      setIsLoading(false)
-    }
-
-    loadSparAddress()
-  }, [supabase, router])
 
   const handleNext = async (stepData: Partial<CompanySettings>) => {
     // Reset org_number/company_name only on a genuine change (user going back
@@ -224,14 +181,6 @@ export default function WelcomeOnboarding({
     if (currentStep > 1) {
       setCurrentStep(currentStep - 1)
     }
-  }
-
-  if (isLoading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-      </div>
-    )
   }
 
   const stepInfo = STEP_INFO[currentStep - 1]

--- a/lib/company/actions.ts
+++ b/lib/company/actions.ts
@@ -232,11 +232,11 @@ export async function createCompanyFromOnboarding(params: {
  * fetched from `/api/extensions/ext/tic/lookup`, plus the `EnrichmentCompanyRole`
  * minimums (org number, legal name, legal entity type). This action derives
  * sensible defaults (accrual, quarterly moms for VAT-registered, Jan-Dec
- * fiscal year), reads SPAR address from `extension_data` as a fallback, and
- * then delegates to `createCompanyFromOnboarding` so the provisioning path is
- * identical to the manual wizard. On success it clears the enrichment row
- * consumed by this path — the manual wizard leaves it intact so a returning
- * BankID user can still reach `/select-company` and pick another directorship.
+ * fiscal year) and delegates to `createCompanyFromOnboarding` so the
+ * provisioning path is identical to the manual wizard. On success it clears
+ * the enrichment row consumed by this path — the manual wizard leaves it
+ * intact so a returning BankID user can still reach `/select-company` and
+ * pick another directorship.
  *
  * Requires `lookup` to be non-null: if TIC `/lookup` is unreachable, the client
  * must route to the manual wizard instead. Silently defaulting `vat_registered`
@@ -277,23 +277,20 @@ export async function createCompanyFromTicRole(params: {
     return { error: 'company_ceased' }
   }
 
-  // SPAR address fallback if the TIC lookup didn't include one.
+  // Look up the enrichment row so we can delete it after successful
+  // provisioning (one-time use). We only need `id` here; the picker has
+  // already used the `companyRoles` field server-side to render the cards.
   const { data: enrichmentRow } = await supabase
     .from('extension_data')
-    .select('id, value')
+    .select('id')
     .eq('user_id', user.id)
     .eq('extension_id', 'tic')
     .eq('key', 'bankid_enrichment')
     .maybeSingle()
 
-  const spar = (enrichmentRow?.value as { spar?: Record<string, string | undefined> } | null)?.spar
-  const sparStreet = spar?.Folkbokforingsadress_SvenskAdress_Utdelningsadress1
-  const sparPostal = spar?.Folkbokforingsadress_SvenskAdress_PostNr
-  const sparCity = spar?.Folkbokforingsadress_SvenskAdress_Postort
-
-  const addressStreet = params.lookup.address?.street ?? sparStreet ?? null
-  const addressPostal = params.lookup.address?.postalCode ?? sparPostal ?? null
-  const addressCity = params.lookup.address?.city ?? sparCity ?? null
+  const addressStreet = params.lookup.address?.street ?? null
+  const addressPostal = params.lookup.address?.postalCode ?? null
+  const addressCity = params.lookup.address?.city ?? null
 
   const fTax = params.lookup.registration.fTax
   const vatRegistered = params.lookup.registration.vat


### PR DESCRIPTION
## Summary

We only request \`['CompanyRoles']\` from TIC enrichment (since #349), so \`enrichmentData.spar\` is never populated. Two code paths still read it through \`spar?\` guards — dead branches that'll never trigger. Remove them so the next reader isn't confused.

## Changes

- **\`WelcomeOnboarding.tsx\`:** remove the \`loadSparAddress\` useEffect and its gated loading spinner. The server component (\`app/(onboarding)/onboarding/page.tsx\`) already handles the auth redirect, so the client-side auth check inside the effect was redundant. Also drops now-unused imports (\`useEffect\`, \`createClient\`, \`Loader2\`) and the \`isLoading\` state.
- **\`actions.ts\` (\`createCompanyFromTicRole\`):** remove the SPAR address fallback chain. Keep the \`extension_data\` lookup (still needed for the one-time-use row delete after provisioning).

Net: -54 lines.

## Does this unblock production?

**No.** Enrichment is still failing upstream at TIC with \`'Session not completed'\` for our tenant due to a split-brain between their consent dialog and \`/enrichment/types\` — separate issue being tracked with TIC support. This PR is code hygiene only; once TIC fixes the tenant config, everything just starts working.

## Test plan

- [x] All 2315 tests pass
- [x] \`npx tsc --noEmit\` clean on touched files
- [ ] After merge: BankID signup in preview still reaches \`/onboarding\` with no regressions (SPAR path was never firing in prod anyway)

🤖 Generated with [Claude Code](https://claude.com/claude-code)