### PR TITLE
fix(security): harden cron auth, log endpoint, and MFA QR rendering

### DIFF
--- a/app/(auth)/mfa/enroll/page.tsx
+++ b/app/(auth)/mfa/enroll/page.tsx
@@ -218,10 +218,14 @@ function MfaEnrollContent() {
         <div className="rounded-xl border bg-card p-6 space-y-6" style={{ boxShadow: 'var(--shadow-md)' }}>
           {/* QR Code */}
           <div className="flex justify-center">
-            <div
-              className="rounded-lg border bg-white p-3"
-              dangerouslySetInnerHTML={{ __html: qrCode }}
-            />
+            <div className="rounded-lg border bg-white p-3">
+              <img
+                src={qrCode.startsWith('data:') ? qrCode : `data:image/svg+xml;base64,${btoa(qrCode)}`}
+                alt="QR-kod för tvåfaktorsautentisering"
+                width={160}
+                height={160}
+              />
+            </div>
           </div>
 
           {/* Manual secret */}

--- a/app/(auth)/mfa/enroll/page.tsx
+++ b/app/(auth)/mfa/enroll/page.tsx
@@ -220,7 +220,7 @@ function MfaEnrollContent() {
           <div className="flex justify-center">
             <div className="rounded-lg border bg-white p-3">
               <img
-                src={qrCode.startsWith('data:') ? qrCode : `data:image/svg+xml;base64,${btoa(qrCode)}`}
+                src={qrCode.startsWith('data:') ? qrCode : `data:image/svg+xml,${encodeURIComponent(qrCode)}`}
                 alt="QR-kod för tvåfaktorsautentisering"
                 width={160}
                 height={160}

--- a/app/api/events/cleanup/cron/route.ts
+++ b/app/api/events/cleanup/cron/route.ts
@@ -1,5 +1,6 @@
 import { createServiceClient } from '@/lib/supabase/server'
 import { NextResponse } from 'next/server'
+import { verifyCronSecret } from '@/lib/auth/cron'
 
 /**
  * GET /api/events/cleanup/cron
@@ -7,12 +8,8 @@ import { NextResponse } from 'next/server'
  * Runs at 02:00 UTC every day.
  */
 export async function GET(request: Request) {
-  const authHeader = request.headers.get('authorization')
-  const cronSecret = process.env.CRON_SECRET
-
-  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  }
+  const authError = verifyCronSecret(request)
+  if (authError) return authError
 
   try {
     const supabase = await createServiceClient()

--- a/app/api/extensions/push-notifications/cron/route.ts
+++ b/app/api/extensions/push-notifications/cron/route.ts
@@ -1,6 +1,7 @@
 import { createClient } from '@supabase/supabase-js'
 import { NextResponse } from 'next/server'
 import { loadExtensions } from '@/lib/extensions/loader'
+import { verifyCronSecret } from '@/lib/auth/cron'
 import {
   sendTaxDeadlineNotifications,
   sendInvoiceNotifications,
@@ -18,13 +19,8 @@ export async function GET(request: Request) {
   // Ensure extensions are loaded so event handlers are registered
   loadExtensions()
 
-  // Verify cron secret for security
-  const authHeader = request.headers.get('authorization')
-  const cronSecret = process.env.CRON_SECRET
-
-  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  }
+  const authError = verifyCronSecret(request)
+  if (authError) return authError
 
   // Create a service role client for accessing all user data
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL

--- a/app/api/log/route.ts
+++ b/app/api/log/route.ts
@@ -1,6 +1,11 @@
+import { createClient } from '@/lib/supabase/server'
 import { NextResponse } from 'next/server'
 
 export async function POST(request: Request) {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ ok: false }, { status: 401 })
+
   try {
     const { message, extra } = await request.json()
 

--- a/app/api/log/route.ts
+++ b/app/api/log/route.ts
@@ -9,8 +9,11 @@ export async function POST(request: Request) {
   try {
     const { message, extra } = await request.json()
 
+    const sanitize = (s: unknown) =>
+      typeof s === 'string' ? s.replace(/[\r\n\t\x00-\x1f\x7f]/g, ' ').slice(0, 500) : ''
+
     // This console.error runs server-side → visible in Vercel Logs
-    console.error('[onboarding]', message, extra ? JSON.stringify(extra) : '')
+    console.error('[onboarding]', sanitize(message), extra ? sanitize(JSON.stringify(extra)) : '')
 
     return NextResponse.json({ ok: true })
   } catch {


### PR DESCRIPTION
## Summary

Fixes three medium-severity findings from a security audit:

- **Timing attack on cron secret** — two routes (`/api/events/cleanup/cron`, `/api/extensions/push-notifications/cron`) used plain `!==` to compare the cron secret. Replaced with the existing `verifyCronSecret()` helper which uses `crypto.timingSafeEqual()` via SHA-256 hashing.
- **Unauthenticated `/api/log` endpoint** — no auth check allowed any unauthenticated actor to write arbitrary entries to server-side logs (log flooding / log injection). Added Supabase auth guard; unauthenticated requests now receive 401.
- **`dangerouslySetInnerHTML` on MFA enroll page** — the TOTP QR code SVG from Supabase was rendered without sanitization. Replaced with an `<img>` tag using the data URI directly (or base64-encoding raw SVG), eliminating the XSS vector.

## Test plan

- [ ] Cron routes return 401 with wrong/missing secret, 200 with correct secret
- [ ] `POST /api/log` returns 401 when unauthenticated, 200 when authenticated
- [ ] MFA enroll page renders QR code correctly (scan with authenticator app)
- [ ] CI core build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)