### PR TITLE
fix(invoices): init remaining_amount on create + attach invoice PDF to payment JE

### DIFF
--- a/app/api/invoices/route.ts
+++ b/app/api/invoices/route.ts
@@ -182,6 +182,13 @@ export const POST = withRouteContext(
         vat_amount_sek: documentType === 'delivery_note' ? null : vatAmountSek,
         total,
         total_sek: documentType === 'delivery_note' ? null : totalSek,
+        // Initialize remaining_amount to total for real invoices so the open-
+        // invoice queries (InvoicePicker, AR ledger, supplier matching) treat
+        // newly-created invoices as fully unpaid. The DB default is 0 — without
+        // this, brand-new fakturor look settled and disappear from match
+        // candidate lists. Proformas and delivery notes have no payment
+        // obligation, so they keep the 0 default.
+        remaining_amount: documentType === 'invoice' ? total : 0,
         vat_treatment: vatRules.treatment,
         vat_rate: documentType === 'delivery_note' ? 0 : (isMixedRate ? null : (uniqueRates.values().next().value ?? vatRules.rate)),
         moms_ruta: vatRules.momsRuta,

--- a/app/api/transactions/[id]/match-invoice/route.ts
+++ b/app/api/transactions/[id]/match-invoice/route.ts
@@ -179,6 +179,41 @@ export const POST = withRouteContext(
       }
     }
 
+    // Underlag for the payment verifikation: re-attach the invoice PDF that
+    // was archived on send to the new payment journal entry. document_
+    // attachments.journal_entry_id is one-to-one, so we insert a parallel
+    // row pointing at the same storage_path. Same WORM file, second JE
+    // pointer — no copy, no schema change. Non-blocking (BFL 7 kap audit
+    // gap, but the bank line + invoice still exist as evidence).
+    if (journalEntryId && invoice.journal_entry_id) {
+      try {
+        const { data: invoiceDoc } = await supabase
+          .from('document_attachments')
+          .select('storage_path, file_name, file_size_bytes, mime_type, sha256_hash')
+          .eq('journal_entry_id', invoice.journal_entry_id)
+          .eq('company_id', companyId)
+          .eq('is_current_version', true)
+          .limit(1)
+          .maybeSingle()
+        if (invoiceDoc) {
+          await supabase.from('document_attachments').insert({
+            user_id: user.id,
+            company_id: companyId,
+            uploaded_by: user.id,
+            upload_source: 'system',
+            storage_path: invoiceDoc.storage_path,
+            file_name: invoiceDoc.file_name,
+            file_size_bytes: invoiceDoc.file_size_bytes,
+            mime_type: invoiceDoc.mime_type,
+            sha256_hash: invoiceDoc.sha256_hash,
+            journal_entry_id: journalEntryId,
+          })
+        }
+      } catch (err) {
+        txLog.warn('failed to attach invoice PDF to payment journal entry', err as Error)
+      }
+    }
+
     // Optimistic lock: only update if invoice is still in a matchable state.
     const { data: updatedRows, error: updateInvError } = await supabase
       .from('invoices')

--- a/app/api/transactions/[id]/match-invoice/route.ts
+++ b/app/api/transactions/[id]/match-invoice/route.ts
@@ -196,7 +196,12 @@ export const POST = withRouteContext(
           .limit(1)
           .maybeSingle()
         if (invoiceDoc) {
-          await supabase.from('document_attachments').insert({
+          // Destructure error: Supabase client returns { data, error } on
+          // postgres-level failures (unique constraint, RLS reject) instead
+          // of throwing, so the surrounding try/catch only covers thrown
+          // JS exceptions. Log via warn so attachment failures are visible
+          // in logs even though we don't abort the match.
+          const { error: attachErr } = await supabase.from('document_attachments').insert({
             user_id: user.id,
             company_id: companyId,
             uploaded_by: user.id,
@@ -208,6 +213,13 @@ export const POST = withRouteContext(
             sha256_hash: invoiceDoc.sha256_hash,
             journal_entry_id: journalEntryId,
           })
+          if (attachErr) {
+            txLog.warn('failed to attach invoice PDF to payment journal entry', {
+              attachError: attachErr.message,
+              paymentJournalEntryId: journalEntryId,
+              invoiceJournalEntryId: invoice.journal_entry_id,
+            })
+          }
         }
       } catch (err) {
         txLog.warn('failed to attach invoice PDF to payment journal entry', err as Error)


### PR DESCRIPTION
## Summary

Two follow-up fixes to PR #405 that were pushed after the squash-merge and didn't make it into main.

### 1. `remaining_amount` not initialized on invoice create

`invoices.remaining_amount` has DB default `0`. The create path never set it, so brand-new fakturor were stored with `remaining_amount=0` despite no payment having been received. The InvoicePicker filter (`gt remaining_amount 0`, added in #405) hid these invoices from match candidates — surfaced when a real user reported "Inga öppna fakturor" while having 5 sent invoices.

Fix: set `remaining_amount = total` on insert for `document_type='invoice'`. Proformas / delivery notes keep the `0` default (no payment obligation).

**Data backfill ran out-of-band** at the time the bug was found: 46 affected rows across 20 companies (1.32M SEK in orphaned receivables) updated in production. Restricted to `paid_amount IS NULL OR 0` rows so any legitimately-paid invoice with stale status was untouched (verified: 0 such rows existed). No migration needed for new deploys — only the code fix going forward.

### 2. Invoice PDF not attached to the payment verifikation

The payment JE created on transaction match (debit 1930 / credit 1510) had no document attachment. The invoice PDF was archived on send and pinned to the AR-booking JE, but `document_attachments.journal_entry_id` is one-to-one — leaving the payment JE without underlag, a BFL 7 kap audit-trail gap.

Cheapest fix: after the payment JE is created, look up the invoice's existing `document_attachment` and insert a parallel row pointing at the same `storage_path` with the new `journal_entry_id`. Single WORM file, two DB pointers — no schema change, no file copy. Wrapped in non-blocking try/catch so a document lookup failure doesn't abort the payment match.

## Test plan

- [ ] `npm test -- app/api/invoices app/api/transactions/[id]/match-invoice` (75 tests pass)
- [ ] Create a new invoice → confirm `remaining_amount = total` in DB
- [ ] Match an income transaction to an open invoice → confirm a second `document_attachments` row is inserted with `journal_entry_id` = payment JE id and `storage_path` = invoice's existing PDF path

🤖 Generated with [Claude Code](https://claude.com/claude-code)