### PR TITLE
fix(invoice-inbox): stub DOM globals so pdfjs runs on Vercel

### DIFF
--- a/extensions/general/invoice-inbox/lib/extract-invoice-fields.ts
+++ b/extensions/general/invoice-inbox/lib/extract-invoice-fields.ts
@@ -96,6 +96,16 @@ async function tryExtractPdfText(input: ExtractionInput): Promise<string | null>
   if (input.mimeType !== 'application/pdf') return null
 
   try {
+    // pdfjs-dist references DOMMatrix/ImageData/Path2D at module load. On
+    // Vercel's Node runtime these globals don't exist; without stubs the
+    // import throws "DOMMatrix is not defined" before getDocument() runs.
+    // We only call getTextContent (no rendering), so empty-class stubs are
+    // enough — pdfjs never invokes any methods on them.
+    const g = globalThis as unknown as { DOMMatrix?: unknown; ImageData?: unknown; Path2D?: unknown }
+    if (typeof g.DOMMatrix === 'undefined') g.DOMMatrix = class {}
+    if (typeof g.ImageData === 'undefined') g.ImageData = class {}
+    if (typeof g.Path2D === 'undefined') g.Path2D = class {}
+
     const pdfjs = await import('pdfjs-dist/legacy/build/pdf.mjs')
     const loadingTask = pdfjs.getDocument({
       data: new Uint8Array(input.buffer),

--- a/extensions/general/invoice-inbox/lib/extract-invoice-fields.ts
+++ b/extensions/general/invoice-inbox/lib/extract-invoice-fields.ts
@@ -13,6 +13,18 @@ import type { InvoiceExtractionResult } from '@/types'
 import { normalizeOrgNumber } from '@/lib/company-lookup/normalize-org-number'
 import { validateOcrReference, validateBankgiroNumber } from '@/lib/bankgiro/luhn'
 
+// pdfjs-dist references DOMMatrix/ImageData/Path2D at module load. On
+// Vercel's Node runtime these globals don't exist; without stubs the
+// dynamic import throws "DOMMatrix is not defined" before getDocument()
+// runs. We only call getTextContent (no rendering), so empty-class stubs
+// are enough — pdfjs never invokes any methods on them.
+{
+  const g = globalThis as unknown as { DOMMatrix?: unknown; ImageData?: unknown; Path2D?: unknown }
+  if (typeof g.DOMMatrix === 'undefined') g.DOMMatrix = class {}
+  if (typeof g.ImageData === 'undefined') g.ImageData = class {}
+  if (typeof g.Path2D === 'undefined') g.Path2D = class {}
+}
+
 // Below this we treat the document as image-only / unreadable and skip
 // regex extraction. pdfjs-dist returns near-zero text for scanned PDFs.
 const MIN_TEXT_CHARS_FOR_EXTRACTION = 10
@@ -96,16 +108,6 @@ async function tryExtractPdfText(input: ExtractionInput): Promise<string | null>
   if (input.mimeType !== 'application/pdf') return null
 
   try {
-    // pdfjs-dist references DOMMatrix/ImageData/Path2D at module load. On
-    // Vercel's Node runtime these globals don't exist; without stubs the
-    // import throws "DOMMatrix is not defined" before getDocument() runs.
-    // We only call getTextContent (no rendering), so empty-class stubs are
-    // enough — pdfjs never invokes any methods on them.
-    const g = globalThis as unknown as { DOMMatrix?: unknown; ImageData?: unknown; Path2D?: unknown }
-    if (typeof g.DOMMatrix === 'undefined') g.DOMMatrix = class {}
-    if (typeof g.ImageData === 'undefined') g.ImageData = class {}
-    if (typeof g.Path2D === 'undefined') g.Path2D = class {}
-
     const pdfjs = await import('pdfjs-dist/legacy/build/pdf.mjs')
     const loadingTask = pdfjs.getDocument({
       data: new Uint8Array(input.buffer),

--- a/next.config.ts
+++ b/next.config.ts
@@ -20,6 +20,11 @@ const cspDirectives = [
 
 const nextConfig: NextConfig = {
   output: 'standalone',
+  // Keep pdfjs-dist out of the bundle. The legacy build references
+  // @napi-rs/canvas at module load and breaks Vercel's bundling step.
+  // Text extraction works in pure Node once DOM globals are stubbed at
+  // the call site (see extensions/general/invoice-inbox/lib/extract-invoice-fields.ts).
+  serverExternalPackages: ['pdfjs-dist'],
   async redirects() {
     return [
       {


### PR DESCRIPTION
## Summary
- Stub `DOMMatrix`/`ImageData`/`Path2D` as empty classes before `pdfjs-dist` import — fixes `DOMMatrix is not defined` on Vercel's Node runtime
- Add `pdfjs-dist` to `serverExternalPackages` so Next.js skips bundling (the bundler pulls in `@napi-rs/canvas` references that aren't installed)

## Why
Discovered while debugging the invoice-inbox webhook in prod (#torsken-co-ab-jheg test). Inbox items were created successfully but `extracted_data` came back empty for every PDF — pdfjs's module-level code references DOM globals that don't exist on Node, so `getDocument()` never ran. We only call `getTextContent` (no rendering), so empty-class stubs are sufficient — pdfjs never invokes any methods on them.

## Test plan
- [x] Existing 45 invoice-inbox unit tests pass
- [ ] After deploy: send a test PDF email to a company inbox, verify `extracted_data` populates (org-nr, OCR, totals, etc.)
- [ ] Confirm Vercel logs no longer contain `Cannot load "@napi-rs/canvas"` warnings or `pdfjs failed: DOMMatrix is not defined`

🤖 Generated with [Claude Code](https://claude.com/claude-code)