### PR TITLE
fix(invoice-inbox): ship pdfjs worker file to Vercel

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -28,8 +28,10 @@ const nextConfig: NextConfig = {
   // Force the pdfjs worker file into the function bundle. Next.js's tracer
   // can't see it (loaded dynamically by name), so without this it's missing
   // in /var/task and getDocument() fails with "Setting up fake worker failed".
+  // Scoped to the invoice-inbox sub-path — other extensions don't use pdfjs
+  // and shouldn't pay the ~1 MB worker cost.
   outputFileTracingIncludes: {
-    '/api/extensions/ext/**': ['./node_modules/pdfjs-dist/legacy/build/pdf.worker.mjs'],
+    '/api/extensions/ext/invoice-inbox/**': ['./node_modules/pdfjs-dist/legacy/build/pdf.worker.mjs'],
   },
   async redirects() {
     return [

--- a/next.config.ts
+++ b/next.config.ts
@@ -23,8 +23,14 @@ const nextConfig: NextConfig = {
   // Keep pdfjs-dist out of the bundle. The legacy build references
   // @napi-rs/canvas at module load and breaks Vercel's bundling step.
   // Text extraction works in pure Node once DOM globals are stubbed at
-  // the call site (see extensions/general/invoice-inbox/lib/extract-invoice-fields.ts).
+  // module load (see extensions/general/invoice-inbox/lib/extract-invoice-fields.ts).
   serverExternalPackages: ['pdfjs-dist'],
+  // Force the pdfjs worker file into the function bundle. Next.js's tracer
+  // can't see it (loaded dynamically by name), so without this it's missing
+  // in /var/task and getDocument() fails with "Setting up fake worker failed".
+  outputFileTracingIncludes: {
+    '/api/extensions/ext/**': ['./node_modules/pdfjs-dist/legacy/build/pdf.worker.mjs'],
+  },
   async redirects() {
     return [
       {


### PR DESCRIPTION
## Summary
Adds `outputFileTracingIncludes` so `pdfjs-dist/legacy/build/pdf.worker.mjs` ships with the function bundle.

## Why
Follow-up to #407. After DOM globals were stubbed, prod logs surfaced the next pdfjs failure:

\`\`\`
Setting up fake worker failed: "Cannot find module
'/var/task/node_modules/pdfjs-dist/legacy/build/pdf.worker.mjs'
imported from /var/task/node_modules/pdfjs-dist/legacy/build/pdf.mjs"
\`\`\`

pdfjs loads its worker via dynamic \`import()\` at runtime. Next.js's tracer can't see that, so with \`serverExternalPackages: ['pdfjs-dist']\` the main entry ships but the worker file gets pruned.

\`outputFileTracingIncludes\` forces the worker into any function whose route matches \`/api/extensions/ext/**\` — which is where invoice-inbox is dispatched.

## Test plan
- [ ] After deploy: send a PDF to a company inbox address, verify Vercel logs have no \`Setting up fake worker failed\`
- [ ] Confirm \`extracted_data\` populates (org-nr, totals, OCR, dates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)