### PR TITLE
fix(csp): allow Supabase Storage in frame-src for PDF previews

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -14,7 +14,7 @@ const cspDirectives = [
   "img-src 'self' data: blob: https:",
   "font-src 'self'",
   "worker-src 'self' blob:",
-  `frame-src 'self'${activepiecesUrl ? ` ${activepiecesUrl}` : ""}`,
+  `frame-src 'self' https://*.supabase.co${activepiecesUrl ? ` ${activepiecesUrl}` : ""}`,
   "frame-ancestors 'none'",
 ].join("; ");
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -14,7 +14,7 @@ const cspDirectives = [
   "img-src 'self' data: blob: https:",
   "font-src 'self'",
   "worker-src 'self' blob:",
-  `frame-src 'self' https://*.supabase.co${activepiecesUrl ? ` ${activepiecesUrl}` : ""}`,
+  `frame-src 'self' ${supabaseUrl}${activepiecesUrl ? ` ${activepiecesUrl}` : ""}`,
   "frame-ancestors 'none'",
 ].join("; ");
 


### PR DESCRIPTION
## Summary
Allow \`https://*.supabase.co\` in CSP \`frame-src\` so PDF previews render in the invoice-inbox workspace (and anywhere else the app embeds Supabase-hosted files).

## Why
After #409 landed (unpdf migration) text extraction works in prod — fields populate correctly. But the inbox UI renders the attached PDF in an \`<iframe>\` pointed at a Supabase Storage signed URL, and Firefox/Chrome were blocking it:

> Det här innehållet har blockerats. Kontakta webbplatsägaren om du vill åtgärda problemet.

CSP \`frame-src 'self'\` doesn't cover \`*.supabase.co\`. Adding it lines up with the same Supabase trust boundary we already accept on \`connect-src\`. Signed URLs are short-lived so exposure is minimal.

## Test plan
- [ ] After deploy: open an invoice-inbox row in the UI, verify the PDF preview renders inline instead of showing the blocked-content message
- [ ] Confirm no new CSP violations in browser devtools console

🤖 Generated with [Claude Code](https://claude.com/claude-code)