### PR TITLE
fix(dashboard): container leaks after extension workspace navigation

### DIFF
--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -2,6 +2,7 @@ import { createClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
 import { headers } from 'next/headers'
 import DashboardNav from '@/components/dashboard/DashboardNav'
+import { MainContainer } from '@/components/dashboard/MainContainer'
 import CompanyTabSync from '@/components/dashboard/CompanyTabSync'
 import { RecaptIdentify } from '@/components/RecaptIdentify'
 import { SandboxBanner } from '@/components/dashboard/SandboxBanner'
@@ -222,16 +223,7 @@ export default async function DashboardLayout({
           extensionNavItems={getExtensionNavItems()}
         />
         <main id="main-content" className="safe-area-main-padding md:!pb-0 md:pl-[232px]" role="main">
-          {pathname.startsWith('/e/') ? (
-            // Extension workspaces opt out of the centered max-w-5xl chrome
-            // because their content (file viewers, dashboards) wants the full
-            // viewport width.
-            <div key={companyId} className="h-full">{children}</div>
-          ) : (
-            <div key={companyId} className="max-w-5xl mx-auto px-5 py-8 md:px-8 md:py-10">
-              {children}
-            </div>
-          )}
+          <MainContainer companyId={companyId}>{children}</MainContainer>
         </main>
         {!isSandbox && (
           <RecaptIdentify

--- a/components/dashboard/MainContainer.tsx
+++ b/components/dashboard/MainContainer.tsx
@@ -22,7 +22,7 @@ export function MainContainer({
   children: ReactNode
 }) {
   const pathname = usePathname()
-  const isExtensionWorkspace = pathname?.startsWith('/e/') ?? false
+  const isExtensionWorkspace = pathname.startsWith('/e/')
 
   return isExtensionWorkspace ? (
     <div key={companyId ?? ''} className="h-full">{children}</div>

--- a/components/dashboard/MainContainer.tsx
+++ b/components/dashboard/MainContainer.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import type { ReactNode } from 'react'
+
+/**
+ * Picks the dashboard chrome container based on route. Extension workspaces
+ * (/e/*) want the full viewport for file viewers and dashboards; everything
+ * else gets the centered max-w-5xl card.
+ *
+ * Lives in a client component because the parent (dashboard) layout is
+ * shared across all dashboard routes. Server-side pathname checks done in
+ * the layout don't re-evaluate reliably on soft navigation between sibling
+ * routes, so the wrapper class would otherwise stick on whichever branch
+ * the first render picked.
+ */
+export function MainContainer({
+  companyId,
+  children,
+}: {
+  companyId: string | null
+  children: ReactNode
+}) {
+  const pathname = usePathname()
+  const isExtensionWorkspace = pathname?.startsWith('/e/') ?? false
+
+  return isExtensionWorkspace ? (
+    <div key={companyId ?? ''} className="h-full">{children}</div>
+  ) : (
+    <div
+      key={companyId ?? ''}
+      className="max-w-5xl mx-auto px-5 py-8 md:px-8 md:py-10"
+    >
+      {children}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
Move the dashboard container-vs-full-width selection from a server header check into a client component that subscribes to \`usePathname()\`.

## Problem
After visiting \`/e/general/invoice-inbox\` and then clicking any sidebar item back to a regular dashboard page (\`/\`, \`/transactions\`, \`/fakturor\`, …), the page rendered edge-to-edge with no \`max-w-5xl\` container or horizontal padding. Reload fixed it.

Repro:
1. Open \`/\` — centered card layout (correct)
2. Open \`/e/general/invoice-inbox\` — full width (correct)
3. Click \"Översikt\" or any other sidebar item — still full width 🐛

## Root cause
\`app/(dashboard)/layout.tsx:225-234\` picked the wrapper based on \`headers().get('x-pathname')\`. The dashboard layout is shared across every dashboard route, so on soft navigation between sibling routes Next.js doesn't re-evaluate the server header path reliably enough to keep the conditional in sync. Whichever branch the layout's first render picked stuck until a hard reload.

The bug existed since the conditional was introduced; \`/e/*\` is just the first route family that opts out of the centered chrome and exposes it.

## Fix
Extract the conditional into \`components/dashboard/MainContainer.tsx\` (client component) that uses \`usePathname()\`. The hook re-runs on every navigation, so the wrapper className always tracks the current route.

Server layout unchanged otherwise — \`isNoCompanyAllowed\` still uses the same \`x-pathname\` header (only fires on initial server render, not affected by this issue).

## Test plan
- [ ] After deploy: open \`/\`, navigate to \`/e/general/invoice-inbox\`, navigate back to \`/\` — confirm centered card returns without reload
- [ ] Repeat in reverse and across multiple regular pages — container should track route every time
- [ ] Confirm \`/e/general/invoice-inbox\` still renders full-width as before
- [ ] Confirm \`/extensions\` (marketplace listing) and \`/settings/account\` still render in centered card

🤖 Generated with [Claude Code](https://claude.com/claude-code)