### PR TITLE
feat(invoice-inbox): loading state + review fixes + env-driven config

### DIFF
--- a/components/extensions/general/InvoiceInboxWorkspace.tsx
+++ b/components/extensions/general/InvoiceInboxWorkspace.tsx
@@ -452,10 +452,18 @@ export default function InvoiceInboxWorkspace(_props: WorkspaceComponentProps) {
               onAttach={() => setAttachOpen(true)}
               isDeleting={isDeleting}
               onFieldsUpdated={(nextData) => {
-                setSelected((prev) => (prev ? { ...prev, extracted_data: nextData } : prev))
+                // Guard against stale closure: if the user navigated to a
+                // different item between sending the PATCH and the response
+                // arriving, the captured `selected` is no longer the
+                // currently-selected one. Without the id check we'd write
+                // item A's payload onto item B's row.
+                const targetId = selected.id
+                setSelected((prev) =>
+                  prev?.id === targetId ? { ...prev, extracted_data: nextData } : prev
+                )
                 setItems((prev) =>
                   prev.map((it) =>
-                    it.id === selected.id ? { ...it, extracted_data: nextData } : it
+                    it.id === targetId ? { ...it, extracted_data: nextData } : it
                   )
                 )
               }}

--- a/extensions/general/invoice-inbox/__tests__/extract-invoice-fields.test.ts
+++ b/extensions/general/invoice-inbox/__tests__/extract-invoice-fields.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest'
 import { extractInvoiceFields } from '@/extensions/general/invoice-inbox/lib/extract-invoice-fields'
 
 // Mock the Bedrock SDK so tests drive the JSON parser without
@@ -190,6 +190,3 @@ describe('extractInvoiceFields', () => {
     else delete process.env.AWS_SECRET_ACCESS_KEY
   })
 })
-
-// vitest doesn't auto-import afterAll
-import { afterAll } from 'vitest'

--- a/extensions/general/invoice-inbox/lib/extract-invoice-fields.ts
+++ b/extensions/general/invoice-inbox/lib/extract-invoice-fields.ts
@@ -22,7 +22,13 @@ const log = createLogger('invoice-inbox-extract')
 // production (eu.anthropic.claude-sonnet-4-6 in eu-north-1, 8192 tokens —
 // enough headroom for invoices with 20+ line items).
 const MODEL = process.env.BEDROCK_MODEL_ID || 'eu.anthropic.claude-sonnet-4-6'
-const MAX_TOKENS = Number(process.env.BEDROCK_MAX_TOKENS) || 8192
+const MAX_TOKENS = (() => {
+  const parsed = Number(process.env.BEDROCK_MAX_TOKENS)
+  // Use the env value only if it's a positive number — `||` would also
+  // fall back on a deliberate `0`, masking what is really an invalid
+  // configuration rather than the intent to disable.
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 8192
+})()
 
 // Bedrock supports these document/image media types directly. HEIC/HEIF
 // are not on the list, so we skip AI for those — the inbox row still

--- a/extensions/general/invoice-inbox/lib/extract-invoice-fields.ts
+++ b/extensions/general/invoice-inbox/lib/extract-invoice-fields.ts
@@ -17,12 +17,12 @@ import { createLogger } from '@/lib/logger'
 
 const log = createLogger('invoice-inbox-extract')
 
-const MODEL = 'eu.anthropic.claude-sonnet-4-6'
-// 4096 covers a 10-15 line invoice plus VAT breakdown comfortably. The JSON
-// skeleton alone is ~200 tokens; 1500 left only ~1300 for content and
-// silently truncated complex documents (response cut mid-JSON →
-// JSON.parse throws → row lands with all-null fields).
-const MAX_TOKENS = 4096
+// Both overridable via env vars so ops can swap models / raise token caps
+// without a code deploy. Defaults match what's expected to be set in
+// production (eu.anthropic.claude-sonnet-4-6 in eu-north-1, 8192 tokens —
+// enough headroom for invoices with 20+ line items).
+const MODEL = process.env.BEDROCK_MODEL_ID || 'eu.anthropic.claude-sonnet-4-6'
+const MAX_TOKENS = Number(process.env.BEDROCK_MAX_TOKENS) || 8192
 
 // Bedrock supports these document/image media types directly. HEIC/HEIF
 // are not on the list, so we skip AI for those — the inbox row still


### PR DESCRIPTION
Follow-ups to #415 that didn't make it before merge.

## What's in here

### 1. Loading state for AI extraction (commit \`feaf213\`)
- Optimistic placeholder row inserted into the workspace list the moment an upload starts
- "Tolkar dokument med AI…" caption + spinner in the list, document preview, and fields rail
- 6 skeleton inputs in the fields rail while waiting
- Action buttons hidden during placeholder
- Removed on success or failure (toast on error)

### 2. PR #415 review follow-ups (commit \`feaf213\`)
- \`max_tokens\` 1500 → 4096 (no more silent JSON truncation on multi-line invoices)
- \`NullableDate\` rejects 2026-13-45 / 2026-02-30 with a clean 400
- \`vatRate\` consistent percent integers everywhere (was decimal in lineItems, percent in vatBreakdown)
- Drafts re-seed when server normalises (no flicker, no redundant PATCH)
- 409 conflict shows specific Swedish message ("Posten är låst") instead of generic fallback

### 3. Compliance bot follow-ups (commit \`bbefbe0\`)
- \`lineItems[].vatRate\` and \`vatBreakdown[].rate\` refined to 0–100 range
- \`accountSuggestion\` coerced to null at parse time via \`.transform\` (eliminates intermediate-state window where a hallucinated string could appear)
- PATCH \`currency\` requires ISO 4217 format (\`^[A-Z]{3}\$\`)
- Test fixture \`vatRate\` updated 0.25 → 25

### 4. Env-driven Bedrock config (commit \`d5e1218\`)
- \`BEDROCK_MODEL_ID\` and \`BEDROCK_MAX_TOKENS\` env vars override the constants in code
- Defaults bumped to \`eu.anthropic.claude-sonnet-4-6\` / 8192 tokens (enough headroom for 20+ line-item invoices)
- Already set in Vercel prod alongside \`AWS_*\` credentials

## Production status
- All 5 env vars (\`AWS_ACCESS_KEY_ID\`, \`AWS_SECRET_ACCESS_KEY\`, \`AWS_REGION\`, \`BEDROCK_MODEL_ID\`, \`BEDROCK_MAX_TOKENS\`) are now set in Vercel production.
- After this PR merges + Vercel redeploys, the next inbox upload should finally exercise Bedrock and populate \`extracted_data\` properly.

## Test plan
- [x] All 43 invoice-inbox unit tests pass
- [x] tsc clean
- [ ] After deploy: send a PDF to a company inbox, confirm \`extracted_data\` populates and the loading-state placeholder appears during the wait
- [ ] Edit a field inline, confirm it saves and survives a server-normalised round-trip without redundant PATCH

🤖 Generated with [Claude Code](https://claude.com/claude-code)