### PR TITLE
chore(compliance): upgrade to compliancemaxx@v2

### DIFF
--- a/.github/workflows/compliance-pr.yml
+++ b/.github/workflows/compliance-pr.yml
@@ -1,4 +1,9 @@
-name: compliance — PR mode (advisory)
+name: compliance — review (advisory)
+
+# Lightweight LLM-only review on every PR. ~90s, no Docker scanners.
+# Posts a sticky comment with reasoned findings across all 5 frameworks.
+# The nightly compliance-swarm.yml (mode: audit) provides the deeper
+# scanner-backed coverage.
 
 on:
   pull_request:
@@ -7,24 +12,26 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  security-events: write
 
 concurrency:
-  group: compliance-pr-${{ github.ref }}
+  group: compliance-review-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  compliance:
-    name: PR static checks (advisory)
+  review:
+    name: Compliance review (advisory)
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: erp-mafia/compliancemaxx@v1
+      - uses: erp-mafia/compliancemaxx@v2
         with:
-          mode: pr
           base: ${{ github.event.pull_request.base.sha }}
-          fail-on-findings: false           # advisory while bedding in; flip to true after triage
+          fail-on-findings: false           # advisory while bedding in
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: eu-north-1

--- a/.github/workflows/compliance-swarm.yml
+++ b/.github/workflows/compliance-swarm.yml
@@ -44,9 +44,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: erp-mafia/compliancemaxx@v1
+      - uses: erp-mafia/compliancemaxx@v2
         with:
-          mode: swarm
+          mode: audit                    # v2 name; was `swarm` in v1
           llm-provider: bedrock
           fail-on-findings: false        # observational while bedding in
         env:


### PR DESCRIPTION
## Summary

Upgrades both compliance workflows to compliancemaxx@v2.

## What changes

- **PR check**: switches from `mode: pr` (Docker scanners on every PR) to `mode: review` (LLM-only diff review, default in v2).
  - **~90s instead of ~50s** (similar wall time).
  - **~$0.05/PR** in Bedrock cost (was $0).
  - **Shorter, more reasoned PR comment** — LLM judgement instead of raw scanner output.
- **Nightly swarm**: stays scanner+LLM hybrid; just renames `mode: swarm` → `mode: audit` (v2 name) and bumps the action ref. No behavior change.

## Trade-off

Concrete pattern detection (secrets, CVEs, IaC misconfigs) shifts from per-PR to nightly. The nightly audit catches everything within 24h. If we ever miss a real secret because the LLM didn't pattern-match it, we add `mode: scan` as a parallel job.

## Test plan

- [ ] PR check runs and completes within ~90s
- [ ] Sticky comment posted with reasoned findings (different format from v1 scanner output)
- [ ] Workflow exits 0 (advisory mode; `fail-on-findings: false`)
- [ ] Bedrock auth via existing AWS_ACCESS_KEY_ID/SECRET secrets works