### PR TITLE
fix(sie-import): reject overlap-but-not-contain fiscal periods

### DIFF
--- a/lib/import/__tests__/sie-import.test.ts
+++ b/lib/import/__tests__/sie-import.test.ts
@@ -421,6 +421,37 @@ describe('ensureFiscalPeriod validation', () => {
 
     expect(id).toBe('existing-period-id')
   })
+
+  it('rejects when an existing period overlaps the range but does not fully contain it', async () => {
+    // Regression: previously fell through to the overlapping period silently,
+    // which stamped every imported voucher with a fiscal_period_id whose
+    // window did not cover the voucher's own entry_date — breaking the SIE
+    // invariant and BFL 5 kap. (verifikationsnummer per räkenskapsår).
+    const { supabase, enqueueMany } = createQueuedMockSupabase()
+    enqueueMany([
+      { data: null, error: null }, // containing check — no match
+      {
+        data: [
+          {
+            id: 'calendar-2026',
+            period_start: '2026-01-01',
+            period_end: '2026-12-31',
+            name: 'Räkenskapsår 2026',
+          },
+        ],
+        error: null,
+      },
+    ])
+
+    await expect(
+      ensureFiscalPeriod(
+        supabase as unknown as Supabase,
+        'company-id',
+        '2025-03-01', // Capelix-style broken FY March–Feb
+        '2026-02-28',
+      ),
+    ).rejects.toThrow(/överlappar men matchar inte/)
+  })
 })
 
 describe('linkOpeningBalanceEntryToPeriod', () => {

--- a/lib/import/sie-import.ts
+++ b/lib/import/sie-import.ts
@@ -1744,28 +1744,41 @@ export async function executeSIEImport(
       // a fiscal period whose shape doesn't match the file's #RAR) would
       // produce journal entries stamped to a period that doesn't cover their
       // own entry_date — breaking the SIE invariant and BFL 5 kap.
-      const { data: resolvedPeriod } = await supabase
+      //
+      // Fail closed if the period fetch errors: a silent skip would leave the
+      // exact data-corruption path this guard exists to close.
+      const { data: resolvedPeriod, error: resolvedPeriodError } = await supabase
         .from('fiscal_periods')
         .select('period_start, period_end')
         .eq('id', result.fiscalPeriodId)
         .single()
 
-      if (resolvedPeriod) {
-        const periodStart = new Date(resolvedPeriod.period_start + 'T00:00:00')
-        const periodEnd = new Date(resolvedPeriod.period_end + 'T00:00:00')
-        const outOfRange = parsed.vouchers.filter(
-          (v) => v.date.getTime() < periodStart.getTime() || v.date.getTime() > periodEnd.getTime()
+      if (resolvedPeriodError || !resolvedPeriod) {
+        result.errors.push(
+          `Kunde inte verifiera räkenskapsårets datumintervall innan import: ${resolvedPeriodError?.message ?? 'räkenskapsåret hittades inte'}. Försök igen.`
         )
+        return result
+      }
 
-        if (outOfRange.length > 0) {
-          const sample = outOfRange.slice(0, 3).map(v => `${v.series}${v.number} (${formatDate(v.date)})`).join(', ')
-          result.errors.push(
-            `${outOfRange.length} verifikation${outOfRange.length === 1 ? '' : 'er'} har datum utanför räkenskapsåret ` +
-              `${resolvedPeriod.period_start} – ${resolvedPeriod.period_end}. Exempel: ${sample}${outOfRange.length > 3 ? '…' : ''}. ` +
-              `Importera varje räkenskapsår som en egen SIE-fil — flera år i samma fil stöds inte.`
-          )
-          return result
-        }
+      // Date-only string comparison — sidesteps any latent off-by-one if the
+      // SIE parser ever attaches a time component to v.date. SIE per spec is
+      // YYYYMMDD and our parser normalizes to midnight, but a string compare
+      // matches the underlying DATE columns exactly and is cheap.
+      const periodStart = resolvedPeriod.period_start as string
+      const periodEnd = resolvedPeriod.period_end as string
+      const outOfRange = parsed.vouchers.filter((v) => {
+        const d = formatDate(v.date)
+        return d < periodStart || d > periodEnd
+      })
+
+      if (outOfRange.length > 0) {
+        const sample = outOfRange.slice(0, 3).map(v => `${v.series}${v.number} (${formatDate(v.date)})`).join(', ')
+        result.errors.push(
+          `${outOfRange.length} verifikation${outOfRange.length === 1 ? '' : 'er'} har datum utanför räkenskapsåret ` +
+            `${periodStart} – ${periodEnd}. Exempel: ${sample}${outOfRange.length > 3 ? '…' : ''}. ` +
+            `Importera varje räkenskapsår som en egen SIE-fil — flera år i samma fil stöds inte.`
+        )
+        return result
       }
 
       // Detect partial-year export: if voucher dates don't span the full fiscal year,

--- a/lib/import/sie-import.ts
+++ b/lib/import/sie-import.ts
@@ -236,11 +236,15 @@ export async function ensureFiscalPeriod(
     return containing.id
   }
 
-  // Check for any overlapping period (DB exclusion constraint would reject
-  // a new insert that overlaps). Use the overlapping period instead.
+  // If an existing period overlaps the requested range but does not fully
+  // contain it, we MUST refuse — silently reusing it would stamp every
+  // imported voucher with a fiscal_period_id whose date window doesn't match
+  // the voucher's own date. That breaks the SIE invariant that #VER dates fall
+  // inside #RAR, breaks BFL 5 kap. (verifikationsnummer per räkenskapsår),
+  // and produces wrong-shaped trial balances per period.
   const { data: overlapping } = await supabase
     .from('fiscal_periods')
-    .select('id')
+    .select('id, period_start, period_end, name')
     .eq('company_id', companyId)
     .lte('period_start', endDate)
     .gte('period_end', startDate)
@@ -248,7 +252,12 @@ export async function ensureFiscalPeriod(
     .limit(1)
 
   if (overlapping && overlapping.length > 0) {
-    return overlapping[0].id
+    const existing = overlapping[0]
+    throw new Error(
+      `SIE-filens räkenskapsår (${startDate} – ${endDate}) överlappar men matchar inte ett befintligt räkenskapsår i gnubok ` +
+        `(${existing.name}: ${existing.period_start} – ${existing.period_end}). ` +
+        `Justera räkenskapsåret i Inställningar → Räkenskap så att det matchar SIE-filen exakt, eller importera en SIE-fil som täcker exakt samma period.`
+    )
   }
 
   // Pre-validate against the DB-side enforce_period_start_day trigger so the
@@ -1730,6 +1739,35 @@ export async function executeSIEImport(
 
     // Import transactions (SIE4 only)
     if (options.importTransactions && parsed.vouchers.length > 0 && result.fiscalPeriodId) {
+      // Reject vouchers whose date falls outside the resolved fiscal period.
+      // Without this guard, a SIE file whose #VER dates extend beyond #RAR (or
+      // a fiscal period whose shape doesn't match the file's #RAR) would
+      // produce journal entries stamped to a period that doesn't cover their
+      // own entry_date — breaking the SIE invariant and BFL 5 kap.
+      const { data: resolvedPeriod } = await supabase
+        .from('fiscal_periods')
+        .select('period_start, period_end')
+        .eq('id', result.fiscalPeriodId)
+        .single()
+
+      if (resolvedPeriod) {
+        const periodStart = new Date(resolvedPeriod.period_start + 'T00:00:00')
+        const periodEnd = new Date(resolvedPeriod.period_end + 'T00:00:00')
+        const outOfRange = parsed.vouchers.filter(
+          (v) => v.date.getTime() < periodStart.getTime() || v.date.getTime() > periodEnd.getTime()
+        )
+
+        if (outOfRange.length > 0) {
+          const sample = outOfRange.slice(0, 3).map(v => `${v.series}${v.number} (${formatDate(v.date)})`).join(', ')
+          result.errors.push(
+            `${outOfRange.length} verifikation${outOfRange.length === 1 ? '' : 'er'} har datum utanför räkenskapsåret ` +
+              `${resolvedPeriod.period_start} – ${resolvedPeriod.period_end}. Exempel: ${sample}${outOfRange.length > 3 ? '…' : ''}. ` +
+              `Importera varje räkenskapsår som en egen SIE-fil — flera år i samma fil stöds inte.`
+          )
+          return result
+        }
+      }
+
       // Detect partial-year export: if voucher dates don't span the full fiscal year,
       // the migration adjustment will produce incorrect large deltas for the missing period.
       if (parsed.vouchers.length > 0 && fiscalYearStart && fiscalYearEnd) {


### PR DESCRIPTION
## Summary

- `ensureFiscalPeriod` no longer silently reuses a partially-overlapping fiscal period. If a period fully contains the SIE file's date range, return it. If a period overlaps but doesn't contain, throw a clear Swedish error pointing at the mismatch. Otherwise create a new period as before.
- Adds a pre-import guard in `executeImport` that rejects with a Swedish error if any `#VER` date falls outside the resolved fiscal period (e.g. multi-year SIE files, which gnubok does not yet support).
- Regression test `rejects when an existing period overlaps the range but does not fully contain it`.

## Why

Customer (Capelix AB, broken FY March–Feb) imported their previous fiscal year (2025-03-01 – 2026-02-28) on top of an existing calendar-year period (2026-01-01 – 2026-12-31). `ensureFiscalPeriod` fell through the "any overlapping period" branch and pinned all 116 prior-year vouchers to the calendar period. Voucher numbers A1–A122 ended up mixed across two fiscal years in a single sequence — direct violation of BFL 5 kap. (verifikationsnummer i obruten serie per räkenskapsår) and the SIE invariant that `#VER` dates fall inside `#RAR`.

## Out of scope (follow-up)

- DB-level `enforce_entry_date_within_period` trigger. Drafted but dropped from this PR because `reverseEntry` (`lib/bookkeeping/engine.ts:400-432`) may legitimately produce reversal-date-outside-original-period writes. Needs an audit of every `journal_entries` writer (currency-revaluation, year-end, storno-service, bank-reconciliation) before adding a global constraint.
- Multi-year SIE auto-split. The standard SIE migration path is one file per fiscal year; rejection with a clear message is the right behavior for now.

## Test plan

- [x] `npx vitest run lib/import` — 396 tests pass
- [x] `npm test` — 2857 tests pass across 199 files
- [ ] Manual repro on a clean test company: import current-year SIE, then previous-year SIE → confirm previous-year import now fails with the Swedish overlap error instead of corrupting data
- [ ] Verify customer can re-onboard cleanly post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)