### PR TITLE
fix(settings): label first-year period as "Första räkenskapsåret"

### DIFF
--- a/components/settings/FiscalPeriodEditor.tsx
+++ b/components/settings/FiscalPeriodEditor.tsx
@@ -288,7 +288,7 @@ function BlockedState({
       </div>
       <div className="text-sm text-muted-foreground space-y-1">
         <p>
-          Nuvarande period:{' '}
+          Första räkenskapsåret:{' '}
           <span className="font-medium text-foreground">
             {formatSwedishDate(period.period_start)} &ndash; {formatSwedishDate(period.period_end)}
           </span>


### PR DESCRIPTION
## Summary

The fiscal-period editor on `/settings/company` is intentionally scoped to the **first** (onboarding) fiscal year — it loads the oldest period and lets the user fix it as long as nothing is booked. The locked-state copy, however, called this period **"Nuvarande period:"**, which reads as "your company's current fiscal year".

Renames the label to match the section header (`Första räkenskapsår`). No logic change.

## Test plan
- [ ] Visit `/settings/company` on an account with multiple fiscal years and posted entries → blocked-state card shows `Första räkenskapsåret: <oldest period dates>` instead of `Nuvarande period:`.
- [ ] Visit on a fresh company with one period and 0 posted entries → editor still renders normally (unaffected branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)