### PR TITLE
fix(nav): show Beta badge on Huvudmeny items

### DIFF
--- a/components/dashboard/DashboardNav.tsx
+++ b/components/dashboard/DashboardNav.tsx
@@ -213,7 +213,20 @@ export default function DashboardNav({ companyName: _companyName, entityType, un
                           "mr-2.5 h-[15px] w-[15px] flex-shrink-0",
                           active ? "text-primary" : "text-muted-foreground group-hover:text-foreground"
                         )} />
-                        {item.label}
+                        <span className="flex-1">{item.label}</span>
+                        {item.comingSoon ? (
+                          <span className="ml-auto rounded-full bg-muted/60 text-muted-foreground/70 text-[9px] font-medium uppercase tracking-wider px-1.5 py-0.5">
+                            Kommer snart
+                          </span>
+                        ) : item.devBadge ? (
+                          <span className="ml-auto rounded-full bg-muted/60 text-muted-foreground/70 text-[9px] font-medium uppercase tracking-wider px-1.5 py-0.5">
+                            Dev
+                          </span>
+                        ) : item.betaBadge ? (
+                          <span className="ml-auto rounded-full bg-muted/60 text-muted-foreground/70 text-[9px] font-medium uppercase tracking-wider px-1.5 py-0.5">
+                            Beta
+                          </span>
+                        ) : null}
                       </>
                     )
                     const baseClass = cn(
@@ -551,7 +564,20 @@ export default function DashboardNav({ companyName: _companyName, entityType, un
                   const content = (
                     <>
                       <Icon className={cn("h-[18px] w-[18px] flex-shrink-0", active ? "text-primary" : "text-muted-foreground")} />
-                      <span className="text-sm">{item.label}</span>
+                      <span className="text-sm flex-1">{item.label}</span>
+                      {item.comingSoon ? (
+                        <span className="rounded-full bg-muted/60 text-muted-foreground/70 text-[9px] font-medium uppercase tracking-wider px-1.5 py-0.5">
+                          Kommer snart
+                        </span>
+                      ) : item.devBadge ? (
+                        <span className="rounded-full bg-muted/60 text-muted-foreground/70 text-[9px] font-medium uppercase tracking-wider px-1.5 py-0.5">
+                          Dev
+                        </span>
+                      ) : item.betaBadge ? (
+                        <span className="rounded-full bg-muted/60 text-muted-foreground/70 text-[9px] font-medium uppercase tracking-wider px-1.5 py-0.5">
+                          Beta
+                        </span>
+                      ) : null}
                     </>
                   )
                   const baseClass = cn(


### PR DESCRIPTION
## Summary

Dokumentinkorg has \`betaBadge: true\` (matching Löner / Anställda) but the badge never rendered. Reason: the Huvudmeny group uses its own render loop separate from AR/AP/Personal/Accounting, and that loop only emitted icon + label — no badge support at all. The \`betaBadge\`/\`devBadge\`/\`comingSoon\` flags were silently ignored for any item in \`group: 'main'\`.

Adding the same badge precedence block (\`comingSoon\` → \`devBadge\` → \`betaBadge\`) to both render paths — desktop sidebar and mobile drawer.

## Test plan

- [ ] Sidebar: Dokumentinkorg shows the same Beta pill as Löner and Anställda
- [ ] Mobile drawer: same
- [ ] No regression on Översikt / Nyckeltal (no badge flags → no badge rendered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)