### PR TITLE
fix(docker): self-hosted build-from-source startup failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs
 
 # Copy standalone output
-COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,4 +26,8 @@ services:
       - APP_URL=http://app:3000
     volumes:
       - ./docker/crontab.self-hosted:/etc/supercronic/crontab:ro
+    # Run tini as PID 1 so supercronic does not engage its own process reaper.
+    # Supercronic's reaper path is broken on alpine and exits with
+    # "Failed to fork exec: no such file or directory" before reading the crontab.
+    init: true
     restart: unless-stopped

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -28,13 +28,19 @@ if [ -n "$placeholders_found" ]; then
 fi
 
 # Replace build-time placeholder sentinels with runtime env vars in both client
-# and server JS bundles. Next.js inlines NEXT_PUBLIC_* values at build time into
+# and server bundles. Next.js inlines NEXT_PUBLIC_* values at build time into
 # server code too, so the server bundle must be patched as well — otherwise the
 # inlined placeholder strings reach runtime and break things like Supabase URL
 # parsing in /api/health. This allows a single pre-built image to work with any
 # Supabase project.
+#
+# Beyond .js, the App Router prerenders statically-rendered routes (login,
+# privacy, DPA, landing) into .html/.rsc/.meta/.body sidecars under
+# /app/.next/server/app/. generateMetadata() runs at build time for those, so
+# the resolved <title> string is baked into the prerender artifacts — patching
+# only the .js bundles leaves the placeholder visible on every prerendered page.
 if [ -d /app/.next ]; then
-  find /app/.next -name '*.js' -exec sed -i \
+  find /app/.next -type f \( -name '*.js' -o -name '*.html' -o -name '*.rsc' -o -name '*.meta' -o -name '*.body' \) -exec sed -i \
     -e "s|__NEXT_PUBLIC_SUPABASE_URL__|${NEXT_PUBLIC_SUPABASE_URL}|g" \
     -e "s|__NEXT_PUBLIC_SUPABASE_ANON_KEY__|${NEXT_PUBLIC_SUPABASE_ANON_KEY}|g" \
     -e "s|__NEXT_PUBLIC_APP_URL__|${NEXT_PUBLIC_APP_URL}|g" \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -41,6 +41,7 @@ if [ -d /app/.next ]; then
     -e "s|__NEXT_PUBLIC_VAPID_PUBLIC_KEY__|${NEXT_PUBLIC_VAPID_PUBLIC_KEY:-}|g" \
     -e "s|__NEXT_PUBLIC_SELF_HOSTED__|${NEXT_PUBLIC_SELF_HOSTED:-true}|g" \
     -e "s|__NEXT_PUBLIC_REQUIRE_MFA__|${NEXT_PUBLIC_REQUIRE_MFA:-false}|g" \
+    -e "s|__NEXT_PUBLIC_BRANDING_APP_NAME__|${NEXT_PUBLIC_BRANDING_APP_NAME:-Gnubok}|g" \
     {} +
 fi
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -27,10 +27,14 @@ if [ -n "$placeholders_found" ]; then
   printf "WARNING: These variables appear to contain placeholder values:\n%bPlease set them to real values before running in production.\n" "$placeholders_found" >&2
 fi
 
-# Replace build-time placeholder sentinels with runtime env vars in static JS bundles.
-# This allows a single pre-built image to work with any Supabase project.
-if [ -d /app/.next/static ]; then
-  find /app/.next/static -name '*.js' -exec sed -i \
+# Replace build-time placeholder sentinels with runtime env vars in both client
+# and server JS bundles. Next.js inlines NEXT_PUBLIC_* values at build time into
+# server code too, so the server bundle must be patched as well — otherwise the
+# inlined placeholder strings reach runtime and break things like Supabase URL
+# parsing in /api/health. This allows a single pre-built image to work with any
+# Supabase project.
+if [ -d /app/.next ]; then
+  find /app/.next -name '*.js' -exec sed -i \
     -e "s|__NEXT_PUBLIC_SUPABASE_URL__|${NEXT_PUBLIC_SUPABASE_URL}|g" \
     -e "s|__NEXT_PUBLIC_SUPABASE_ANON_KEY__|${NEXT_PUBLIC_SUPABASE_ANON_KEY}|g" \
     -e "s|__NEXT_PUBLIC_APP_URL__|${NEXT_PUBLIC_APP_URL}|g" \


### PR DESCRIPTION
  These three issues surfaced when running

      docker compose -f docker-compose.yml -f docker-compose.build.yml up --build

  i.e. building the image locally rather than pulling
  ghcr.io/erp-mafia/gnubok:latest. Pulling the pre-built image masked
  them; rebuilding from source exposed each one in turn.

  - Dockerfile: COPY of /app/public was missing --chown=nextjs:nodejs. The nextjs user could not sed-substitute the branding placeholder in public/sw.js, so the entrypoint exited with "Permission denied" before the server ever started. Introduced when sw.js placeholder substitution was added; the existing pre-built image predates it.

  - docker-entrypoint.sh: placeholder substitution only ran over /app/.next/static (client bundles). Next.js inlines NEXT_PUBLIC_* values into the server bundle too, so server code received the literal "__NEXT_PUBLIC_SUPABASE_URL__" string at runtime and /api/health returned 503 with "Invalid supabaseUrl: Must be a valid HTTP or HTTPS URL." Broadened the find to /app/.next so server chunks under /app/.next/server are patched as well.

  - docker-compose.yml: the cron service is always built locally (docker/cron.Dockerfile), so this hit even when the app image was pulled. Supercronic's built-in process reaper crashes with "Failed to fork exec: no such file or directory" when running as PID 1 on alpine, putting the container into a restart loop. Set init: true so Docker injects tini as PID 1 and supercronic detects it is not PID 1 and skips its broken reaper path.