### PR TITLE
fix: allow Chrome's PDF viewer in verifikat document preview

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -93,6 +93,17 @@ const nextConfig: NextConfig = {
       // iframes (used by the verifikat document preview Sheet). Excluded
       // from the catch-all above so these values aren't shadowed by the
       // stricter defaults.
+      //
+      // CSP is intentionally minimal: only `frame-ancestors 'self'`
+      // prevents cross-origin clickjacking on the user's documents.
+      // Adding `object-src 'none'` (or `default-src 'none'`) here breaks
+      // Chrome's built-in PDF viewer — Chrome renders inline PDFs through
+      // an internal <embed>, which the directive forbids, surfacing as
+      // "Det här innehållet har blockerats" in the document preview Sheet.
+      // Firefox uses PDF.js and Edge uses its own viewer, so neither hits
+      // this. See crbug.com/271452. X-Content-Type-Options: nosniff plus
+      // the explicit Content-Type from the route handler already prevent
+      // MIME-confusion abuse.
       {
         source: "/api/documents/:id/inline",
         headers: [
@@ -118,7 +129,7 @@ const nextConfig: NextConfig = {
           },
           {
             key: "Content-Security-Policy",
-            value: "default-src 'none'; script-src 'none'; object-src 'none'; frame-ancestors 'self'",
+            value: "frame-ancestors 'self'",
           },
         ],
       },


### PR DESCRIPTION
## Summary

Chrome users see **"Det här innehållet har blockerats"** when expanding a PDF attachment in the bookkeeping verifikat preview. Firefox and Edge work; JPGs work everywhere.

**Root cause:** The `/api/documents/:id/inline` route ships with this CSP:

```
default-src 'none'; script-src 'none'; object-src 'none'; frame-ancestors 'self'
```

Chrome's built-in PDF viewer renders inline PDFs through an internal `<embed>` element, which is governed by `object-src`. `object-src 'none'` blocks it. Firefox uses PDF.js (no `<embed>`) and Edge has its own viewer — neither hits this. JPGs render via `<img>` which isn't subject to `object-src`. See [crbug.com/271452](https://crbug.com/271452).

**Fix:** Drop the route's CSP to the minimum needed for embeddability — `frame-ancestors 'self'`.

## Why this is safe

The route is a same-origin proxy that streams files from the non-public `documents` bucket. After this change it still ships:

- `X-Content-Type-Options: nosniff` + explicit `Content-Type` from the handler → blocks MIME-confusion abuse
- `X-Frame-Options: SAMEORIGIN` + `frame-ancestors 'self'` → blocks clickjacking
- RLS + explicit `company_id` membership check in the route handler → blocks cross-tenant access

The dropped directives (`default-src 'none'`, `script-src 'none'`) weren't load-bearing here — there's no HTML response surface to inject scripts into; we serve raw PDF/image bytes.

## Reported by

User Anders on Chrome (two desktops + Motorola mobile, all incognito-tested, all still failed). Confirmed working on his Edge and Firefox. He also noted JPG previews work — consistent with the diagnosis.

## Test plan

- [ ] On a Chrome browser, open a journal entry with a PDF attachment in `/bookkeeping/[id]` and expand it — PDF renders inline (no "blockerats" message)
- [ ] Repeat with a JPG attachment — still renders inline
- [ ] Open DevTools → Network → response headers for `/api/documents/:id/inline` → confirm `Content-Security-Policy: frame-ancestors 'self'` (no `object-src`)
- [ ] Confirm no regression in Edge/Firefox

## Out of scope

The `add/delete-uploaded-docs` branch independently bundles this same CSP fix alongside its DELETE-document feature work. When that branch is rebased after this lands, the duplicate change becomes a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)