### PR TITLE
feat(salary): cost centers and per-day hourly rate on the salary calendar

### DIFF
--- a/app/(dashboard)/settings/bookkeeping/page.tsx
+++ b/app/(dashboard)/settings/bookkeeping/page.tsx
@@ -9,6 +9,7 @@ import { PeriodLockingSettings } from '@/components/settings/PeriodLockingSettin
 import { VoucherSeriesManager } from '@/components/settings/VoucherSeriesManager'
 import { VoucherSeriesPerSourceTypeForm } from '@/components/settings/VoucherSeriesPerSourceTypeForm'
 import { PeriodiseringAutoDetectToggle } from '@/components/settings/PeriodiseringAutoDetectToggle'
+import { CostCenterManager } from '@/components/settings/CostCenterManager'
 import { AccountingFrameworkForm } from '@/components/settings/AccountingFrameworkForm'
 import { useSettings } from '@/components/settings/useSettings'
 import { useCompany } from '@/contexts/CompanyContext'
@@ -135,6 +136,11 @@ export default function BookkeepingSettingsPage() {
       {/* Periodisering auto-detect toggle */}
       <div className="border-t border-border/8 pt-8">
         <PeriodiseringAutoDetectToggle />
+      </div>
+
+      {/* Cost centers (kostnadsställen) */}
+      <div className="border-t border-border/8 pt-8">
+        <CostCenterManager />
       </div>
 
       {/* Cross-links */}

--- a/app/api/cost-centers/[id]/route.ts
+++ b/app/api/cost-centers/[id]/route.ts
@@ -1,0 +1,70 @@
+import { createClient } from '@/lib/supabase/server'
+import { NextResponse } from 'next/server'
+import { requireCompanyId } from '@/lib/company/context'
+import { requireWritePermission } from '@/lib/auth/require-write'
+import { validateBody } from '@/lib/api/validate'
+import { UpdateCostCenterSchema } from '@/lib/api/schemas'
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const writeCheck = await requireWritePermission(supabase, user.id)
+  if (!writeCheck.ok) return writeCheck.response
+
+  const companyId = await requireCompanyId(supabase, user.id)
+
+  const validation = await validateBody(request, UpdateCostCenterSchema)
+  if (!validation.success) return validation.response
+
+  const { data, error } = await supabase
+    .from('cost_centers')
+    .update(validation.data)
+    .eq('id', id)
+    .eq('company_id', companyId)
+    .select('id, code, name, is_active')
+    .single()
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  if (!data) {
+    return NextResponse.json({ error: 'Kostnadsstället hittades inte' }, { status: 404 })
+  }
+
+  return NextResponse.json({ data })
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const writeCheck = await requireWritePermission(supabase, user.id)
+  if (!writeCheck.ok) return writeCheck.response
+
+  const companyId = await requireCompanyId(supabase, user.id)
+
+  // Worked-day references are ON DELETE SET NULL; journal lines store the code
+  // as a string, so removing the dimension does not corrupt posted history.
+  const { error } = await supabase
+    .from('cost_centers')
+    .delete()
+    .eq('id', id)
+    .eq('company_id', companyId)
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  return NextResponse.json({ data: { ok: true } })
+}

--- a/app/api/cost-centers/route.ts
+++ b/app/api/cost-centers/route.ts
@@ -1,0 +1,73 @@
+import { createClient } from '@/lib/supabase/server'
+import { NextResponse } from 'next/server'
+import { requireCompanyId } from '@/lib/company/context'
+import { requireWritePermission } from '@/lib/auth/require-write'
+import { validateBody } from '@/lib/api/validate'
+import { CreateCostCenterSchema } from '@/lib/api/schemas'
+
+export async function GET(request: Request) {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const companyId = await requireCompanyId(supabase, user.id)
+
+  // The calendar picker wants active centers only; the settings manager passes
+  // ?include_inactive=true to list everything for editing.
+  const includeInactive = new URL(request.url).searchParams.get('include_inactive') === 'true'
+
+  let query = supabase
+    .from('cost_centers')
+    .select('id, code, name, is_active')
+    .eq('company_id', companyId)
+    .order('code', { ascending: true })
+
+  if (!includeInactive) query = query.eq('is_active', true)
+
+  const { data, error } = await query
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  return NextResponse.json({ data: data ?? [] })
+}
+
+export async function POST(request: Request) {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const writeCheck = await requireWritePermission(supabase, user.id)
+  if (!writeCheck.ok) return writeCheck.response
+
+  const companyId = await requireCompanyId(supabase, user.id)
+
+  const validation = await validateBody(request, CreateCostCenterSchema)
+  if (!validation.success) return validation.response
+
+  const { data, error } = await supabase
+    .from('cost_centers')
+    .insert({
+      company_id: companyId,
+      // Legacy NOT NULL column kept by the multi-tenant refactor — records the
+      // creator; tenant scoping is enforced via company_id + RLS.
+      user_id: user.id,
+      code: validation.data.code,
+      name: validation.data.name,
+    })
+    .select('id, code, name, is_active')
+    .single()
+
+  if (error) {
+    // Unique (company_id, code) violation → friendly 409.
+    if (error.code === '23505') {
+      return NextResponse.json(
+        { error: 'Ett kostnadsställe med den koden finns redan' },
+        { status: 409 },
+      )
+    }
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  return NextResponse.json({ data }, { status: 201 })
+}

--- a/app/api/salary/employees/[id]/worked-hours/batch/route.ts
+++ b/app/api/salary/employees/[id]/worked-hours/batch/route.ts
@@ -72,8 +72,10 @@ export async function POST(
         employee_id: employeeId,
         work_date: date,
         hours: body.hours,
+        hourly_rate: body.hourly_rate ?? null,
         notes: body.notes ?? null,
         salary_run_employee_id: body.salary_run_employee_id ?? null,
+        cost_center_id: body.cost_center_id ?? null,
       })
     if (error) {
       // 24h cap trigger uses ERRCODE check_violation (23514) and a Swedish

--- a/app/api/salary/employees/[id]/worked-hours/route.ts
+++ b/app/api/salary/employees/[id]/worked-hours/route.ts
@@ -49,7 +49,7 @@ export async function GET(
 
   const { data, error } = await supabase
     .from('salary_worked_days')
-    .select('id, work_date, hours, notes, salary_run_employee_id, created_at, updated_at')
+    .select('id, work_date, hours, hourly_rate, notes, salary_run_employee_id, cost_center_id, created_at, updated_at')
     .eq('company_id', companyId)
     .eq('employee_id', employeeId)
     .gte('work_date', query.data.from)
@@ -112,8 +112,10 @@ export async function POST(
       employee_id: employeeId,
       work_date: body.work_date,
       hours: body.hours,
+      hourly_rate: body.hourly_rate ?? null,
       notes: body.notes ?? null,
       salary_run_employee_id: body.salary_run_employee_id ?? null,
+      cost_center_id: body.cost_center_id ?? null,
     })
     .select()
     .single()

--- a/components/salary/SalaryCalendar.tsx
+++ b/components/salary/SalaryCalendar.tsx
@@ -36,7 +36,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
-import { cn } from '@/lib/utils'
+import { cn, formatCurrency } from '@/lib/utils'
 import type { SalaryType } from '@/types'
 
 // ─── Types ─────────────────────────────────────────────────────────
@@ -62,7 +62,15 @@ interface WorkedDay {
   id: string
   work_date: string
   hours: number
+  hourly_rate: number | null
   notes: string | null
+  cost_center_id: string | null
+}
+
+interface CostCenterOption {
+  id: string
+  code: string
+  name: string
 }
 
 interface AbsenceTypeMeta {
@@ -123,6 +131,7 @@ export function SalaryCalendar({
   const [visibleMonth, setVisibleMonth] = useState<Date>(() => startOfMonth(periodStartDate))
   const [absences, setAbsences] = useState<AbsenceDay[]>([])
   const [worked, setWorked] = useState<WorkedDay[]>([])
+  const [costCenters, setCostCenters] = useState<CostCenterOption[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [selected, setSelected] = useState<Set<string>>(new Set())
@@ -166,6 +175,24 @@ export function SalaryCalendar({
     load()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [employeeId, salaryType, visibleMonth.getFullYear(), visibleMonth.getMonth()])
+
+  // Cost centers are a company-level dimension — load once. Only hourly
+  // employees use the worked-hours dialog where the picker appears.
+  useEffect(() => {
+    if (!isHourly) return
+    let cancelled = false
+    fetch('/api/cost-centers')
+      .then(res => (res.ok ? res.json() : { data: [] }))
+      .then(json => { if (!cancelled) setCostCenters(json.data ?? []) })
+      .catch(() => { /* picker degrades to "Inget kostnadsställe" only */ })
+    return () => { cancelled = true }
+  }, [isHourly])
+
+  const costCenterMap = useMemo(() => {
+    const m = new Map<string, CostCenterOption>()
+    for (const c of costCenters) m.set(c.id, c)
+    return m
+  }, [costCenters])
 
   const absenceMap = useMemo(() => {
     const m = new Map<string, AbsenceDay[]>()
@@ -510,6 +537,7 @@ export function SalaryCalendar({
           employeeId={employeeId}
           dates={Array.from(selected).sort()}
           salaryRunEmployeeId={salaryRunEmployeeId}
+          costCenters={costCenters}
           onClose={() => setBulkMode(null)}
           onSaved={(conflicts) => {
             setBulkMode(null)
@@ -544,6 +572,7 @@ export function SalaryCalendar({
           worked={workedMap.get(inspecting)}
           absences={absenceMap.get(inspecting) ?? []}
           isHourly={isHourly}
+          costCenterMap={costCenterMap}
           onClose={() => setInspecting(null)}
           onChanged={() => {
             load()
@@ -563,25 +592,34 @@ interface BulkWorkedDialogProps {
   employeeId: string
   dates: string[]
   salaryRunEmployeeId?: string
+  costCenters: CostCenterOption[]
   onClose: () => void
   onSaved: (conflicts: BulkConflict[]) => void
 }
+
+// Sentinel for the "no cost center" option — Radix Select can't use "" as a value.
+const NO_COST_CENTER = '__none__'
 
 function BulkWorkedDialog({
   employeeId,
   dates,
   salaryRunEmployeeId,
+  costCenters,
   onClose,
   onSaved,
 }: BulkWorkedDialogProps) {
   const [hours, setHours] = useState<string>('8')
+  const [hourlyRate, setHourlyRate] = useState<string>('')
   const [notes, setNotes] = useState<string>('')
+  const [costCenterId, setCostCenterId] = useState<string>(NO_COST_CENTER)
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [conflicts, setConflicts] = useState<BulkConflict[]>([])
 
   const hoursNum = parseFloat(hours)
   const isClear = isFinite(hoursNum) && hoursNum === 0
+  const rateNum = parseFloat(hourlyRate)
+  const hasRate = hourlyRate.trim() !== '' && isFinite(rateNum)
 
   const handleSave = async () => {
     setSubmitting(true)
@@ -590,6 +628,9 @@ function BulkWorkedDialog({
     try {
       if (!isFinite(hoursNum) || hoursNum < 0 || hoursNum > 24) {
         throw new Error('Timmar måste vara mellan 0 och 24')
+      }
+      if (hourlyRate.trim() !== '' && (!isFinite(rateNum) || rateNum < 0)) {
+        throw new Error('Timlön måste vara 0 eller mer')
       }
       // 0 hours = "no worked time on these days" → delete any existing rows.
       // Avoids tripping the DB CHECK (hours > 0) and matches user intent.
@@ -613,8 +654,10 @@ function BulkWorkedDialog({
         body: JSON.stringify({
           dates,
           hours: hoursNum,
+          hourly_rate: hasRate ? rateNum : undefined,
           notes: notes.trim() || undefined,
           salary_run_employee_id: salaryRunEmployeeId,
+          cost_center_id: costCenterId === NO_COST_CENTER ? undefined : costCenterId,
         }),
       })
       const json = await res.json()
@@ -661,6 +704,41 @@ function BulkWorkedDialog({
               Sätt till 0 för att ta bort arbetad tid på de valda dagarna.
             </p>
           </div>
+
+          {!isClear && (
+            <div className="space-y-1.5">
+              <label className="text-xs font-medium" htmlFor="bulk-w-rate">Timlön (valfritt)</label>
+              <input
+                id="bulk-w-rate"
+                type="number"
+                min={0}
+                step={0.01}
+                inputMode="decimal"
+                value={hourlyRate}
+                onChange={(e) => setHourlyRate(e.target.value)}
+                placeholder="Använd anställds timlön"
+                className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm tabular-nums shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              />
+              <p className="text-[11px] text-muted-foreground">
+                Lämna tomt för att använda den anställdas ordinarie timlön. Anges per timme i SEK.
+              </p>
+            </div>
+          )}
+
+          {!isClear && costCenters.length > 0 && (
+            <div className="space-y-1.5">
+              <label className="text-xs font-medium">Kostnadsställe (valfritt)</label>
+              <Select value={costCenterId} onValueChange={setCostCenterId}>
+                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={NO_COST_CENTER}>Inget kostnadsställe</SelectItem>
+                  {costCenters.map(c => (
+                    <SelectItem key={c.id} value={c.id}>{c.code} · {c.name}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
 
           <div className="space-y-1.5">
             <label className="text-xs font-medium" htmlFor="bulk-w-notes">Anteckning (valfri)</label>
@@ -866,6 +944,7 @@ interface DayInspectorDialogProps {
   worked?: WorkedDay
   absences: AbsenceDay[]
   isHourly: boolean
+  costCenterMap: Map<string, CostCenterOption>
   onClose: () => void
   onChanged: () => void
 }
@@ -876,6 +955,7 @@ function DayInspectorDialog({
   worked,
   absences,
   isHourly,
+  costCenterMap,
   onClose,
   onChanged,
 }: DayInspectorDialogProps) {
@@ -943,6 +1023,16 @@ function DayInspectorDialog({
                 <div>
                   <div className="font-medium">Arbetad tid</div>
                   <div className="text-xs text-muted-foreground tabular-nums">{worked.hours} timmar</div>
+                  {worked.hourly_rate != null && (
+                    <div className="text-xs text-muted-foreground tabular-nums">
+                      {formatCurrency(Number(worked.hourly_rate))}/tim
+                    </div>
+                  )}
+                  {worked.cost_center_id && costCenterMap.has(worked.cost_center_id) && (
+                    <div className="text-xs text-muted-foreground">
+                      {costCenterMap.get(worked.cost_center_id)!.code} · {costCenterMap.get(worked.cost_center_id)!.name}
+                    </div>
+                  )}
                   {worked.notes && <div className="text-xs text-muted-foreground italic">{worked.notes}</div>}
                 </div>
               </div>

--- a/components/settings/CostCenterManager.tsx
+++ b/components/settings/CostCenterManager.tsx
@@ -71,7 +71,9 @@ export function CostCenterManager() {
     }
   }
 
-  const patch = async (id: string, body: Record<string, unknown>) => {
+  // Returns true on success so callers (e.g. inline rename) can decide whether
+  // to close their edit UI — errors are surfaced via state, not re-thrown.
+  const patch = async (id: string, body: Record<string, unknown>): Promise<boolean> => {
     setBusyId(id)
     setError(null)
     try {
@@ -83,8 +85,10 @@ export function CostCenterManager() {
       const json = await res.json()
       if (!res.ok) throw new Error(json.error || t('save_error'))
       await load()
+      return true
     } catch (e) {
       setError(e instanceof Error ? e.message : t('save_error'))
+      return false
     } finally {
       setBusyId(null)
     }
@@ -116,8 +120,10 @@ export function CostCenterManager() {
   const saveEdit = async (id: string) => {
     const name = editName.trim()
     if (!name) return
-    await patch(id, { name })
-    setEditingId(null)
+    // Keep the edit field open if the save failed so the user can retry
+    // without losing their in-progress name change.
+    const ok = await patch(id, { name })
+    if (ok) setEditingId(null)
   }
 
   return (

--- a/components/settings/CostCenterManager.tsx
+++ b/components/settings/CostCenterManager.tsx
@@ -1,0 +1,271 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { useTranslations } from 'next-intl'
+import { Check, Loader2, Pencil, Plus, Trash2, X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Badge } from '@/components/ui/badge'
+import { Skeleton } from '@/components/ui/skeleton'
+
+interface CostCenter {
+  id: string
+  code: string
+  name: string
+  is_active: boolean
+}
+
+export function CostCenterManager() {
+  const t = useTranslations('settings_cost_centers')
+  const [centers, setCenters] = useState<CostCenter[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const [newCode, setNewCode] = useState('')
+  const [newName, setNewName] = useState('')
+  const [creating, setCreating] = useState(false)
+
+  // Per-row busy + inline rename state.
+  const [busyId, setBusyId] = useState<string | null>(null)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editName, setEditName] = useState('')
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/cost-centers?include_inactive=true')
+      const json = await res.json()
+      if (!res.ok) throw new Error(json.error || t('load_error'))
+      setCenters(json.data ?? [])
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t('load_error'))
+    } finally {
+      setLoading(false)
+    }
+  }, [t])
+
+  useEffect(() => { load() }, [load])
+
+  const handleCreate = async () => {
+    const code = newCode.trim()
+    const name = newName.trim()
+    if (!code || !name) return
+    setCreating(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/cost-centers', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code, name }),
+      })
+      const json = await res.json()
+      if (!res.ok) throw new Error(json.error || t('save_error'))
+      setNewCode('')
+      setNewName('')
+      await load()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t('save_error'))
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  const patch = async (id: string, body: Record<string, unknown>) => {
+    setBusyId(id)
+    setError(null)
+    try {
+      const res = await fetch(`/api/cost-centers/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      const json = await res.json()
+      if (!res.ok) throw new Error(json.error || t('save_error'))
+      await load()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t('save_error'))
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  const handleDelete = async (c: CostCenter) => {
+    if (!confirm(t('delete_confirm', { code: c.code, name: c.name }))) return
+    setBusyId(c.id)
+    setError(null)
+    try {
+      const res = await fetch(`/api/cost-centers/${c.id}`, { method: 'DELETE' })
+      if (!res.ok) {
+        const json = await res.json().catch(() => ({}))
+        throw new Error(json.error || t('save_error'))
+      }
+      await load()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t('save_error'))
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  const startEdit = (c: CostCenter) => {
+    setEditingId(c.id)
+    setEditName(c.name)
+  }
+
+  const saveEdit = async (id: string) => {
+    const name = editName.trim()
+    if (!name) return
+    await patch(id, { name })
+    setEditingId(null)
+  }
+
+  return (
+    <section className="space-y-4">
+      <div>
+        <h2 className="text-sm font-medium uppercase tracking-wider text-muted-foreground">
+          {t('heading')}
+        </h2>
+        <p className="mt-1 text-xs text-muted-foreground">{t('description')}</p>
+      </div>
+
+      {/* Create row */}
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+        <div className="space-y-1.5 sm:w-32">
+          <label className="text-xs font-medium" htmlFor="cc-code">{t('code_label')}</label>
+          <Input
+            id="cc-code"
+            value={newCode}
+            onChange={(e) => setNewCode(e.target.value)}
+            maxLength={20}
+            placeholder={t('code_placeholder')}
+            className="font-mono"
+          />
+        </div>
+        <div className="space-y-1.5 sm:flex-1">
+          <label className="text-xs font-medium" htmlFor="cc-name">{t('name_label')}</label>
+          <Input
+            id="cc-name"
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            maxLength={100}
+            placeholder={t('name_placeholder')}
+            onKeyDown={(e) => { if (e.key === 'Enter') handleCreate() }}
+          />
+        </div>
+        <Button onClick={handleCreate} disabled={creating || !newCode.trim() || !newName.trim()}>
+          {creating ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <Plus className="mr-1 h-4 w-4" />}
+          {t('add')}
+        </Button>
+      </div>
+
+      {error && (
+        <div className="rounded-md bg-destructive/10 px-3 py-2 text-xs text-destructive">{error}</div>
+      )}
+
+      {/* List */}
+      {loading ? (
+        <div className="space-y-2">
+          <Skeleton className="h-8 w-full" />
+          <Skeleton className="h-8 w-2/3" />
+        </div>
+      ) : centers.length === 0 ? (
+        <p className="text-sm text-muted-foreground">{t('empty_state')}</p>
+      ) : (
+        <div className="divide-y divide-border/8 rounded-lg border border-border">
+          {centers.map((c) => (
+            <div key={c.id} className="flex items-center gap-3 px-4 py-2.5">
+              <span className="w-20 shrink-0 font-mono text-sm tabular-nums">{c.code}</span>
+              {editingId === c.id ? (
+                <Input
+                  value={editName}
+                  onChange={(e) => setEditName(e.target.value)}
+                  maxLength={100}
+                  autoFocus
+                  className="h-8 flex-1"
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') saveEdit(c.id)
+                    if (e.key === 'Escape') setEditingId(null)
+                  }}
+                />
+              ) : (
+                <span className={`flex-1 text-sm ${c.is_active ? '' : 'text-muted-foreground line-through'}`}>
+                  {c.name}
+                </span>
+              )}
+
+              {!c.is_active && editingId !== c.id && (
+                <Badge variant="outline" className="text-[10px]">{t('inactive_badge')}</Badge>
+              )}
+
+              <div className="flex items-center gap-1">
+                {editingId === c.id ? (
+                  <>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8"
+                      onClick={() => saveEdit(c.id)}
+                      disabled={busyId === c.id || !editName.trim()}
+                      aria-label={t('save')}
+                    >
+                      {busyId === c.id ? <Loader2 className="h-4 w-4 animate-spin" /> : <Check className="h-4 w-4" />}
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8"
+                      onClick={() => setEditingId(null)}
+                      disabled={busyId === c.id}
+                      aria-label={t('cancel')}
+                    >
+                      <X className="h-4 w-4" />
+                    </Button>
+                  </>
+                ) : (
+                  <>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8"
+                      onClick={() => startEdit(c)}
+                      disabled={busyId === c.id}
+                      aria-label={t('rename')}
+                    >
+                      <Pencil className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="text-xs"
+                      onClick={() => patch(c.id, { is_active: !c.is_active })}
+                      disabled={busyId === c.id}
+                    >
+                      {busyId === c.id ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : c.is_active ? (
+                        t('deactivate')
+                      ) : (
+                        t('activate')
+                      )}
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8"
+                      onClick={() => handleDelete(c)}
+                      disabled={busyId === c.id}
+                      aria-label={t('delete')}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/lib/api/schemas.ts
+++ b/lib/api/schemas.ts
@@ -1224,6 +1224,13 @@ export const UpsertWorkedDaySchema = z
     hours: z.number().positive().max(24).default(8),
     notes: z.string().max(2000).optional(),
     salary_run_employee_id: uuid.optional(),
+    // Optional cost-center tag. Stored on the day record for reporting; does
+    // not yet flow into line items or the booked journal entry.
+    cost_center_id: uuid.optional(),
+    // Optional per-day hourly wage override. When set, the payroll calculator
+    // pays these hours at this rate instead of the employee's default
+    // hourly_rate; when omitted, it falls back to the employee rate.
+    hourly_rate: nonNegativeAmount.optional(),
     // Optional shift window. Feeds the shift-premium engine — without explicit
     // times, the engine assumes a default 08:00–17:00 day shift. Either both
     // fields are provided or neither.
@@ -1254,6 +1261,12 @@ export const BatchUpsertWorkedDaysSchema = z
     hours: z.number().positive().max(24).default(8),
     notes: z.string().max(2000).optional(),
     salary_run_employee_id: uuid.optional(),
+    // Optional cost-center tag applied to every date in the batch. Stored on
+    // the day record for reporting only.
+    cost_center_id: uuid.optional(),
+    // Optional per-day hourly wage override applied to every date in the batch.
+    // Same fallback behaviour as the single-row endpoint.
+    hourly_rate: nonNegativeAmount.optional(),
     // Optional shift window applied to every date in the batch. Pair both or
     // neither; same fallback behaviour as the single-row endpoint.
     start_time: timeString.optional(),
@@ -1266,6 +1279,24 @@ export const BatchUpsertWorkedDaysSchema = z
       path: ['start_time'],
     },
   )
+
+// ============================================================
+// Cost centers (kostnadsställen) — company dimension
+// ============================================================
+
+export const CreateCostCenterSchema = z.object({
+  code: z.string().trim().min(1).max(20),
+  name: z.string().trim().min(1).max(100),
+})
+
+export const UpdateCostCenterSchema = z
+  .object({
+    name: z.string().trim().min(1).max(100).optional(),
+    is_active: z.boolean().optional(),
+  })
+  .refine((d) => d.name !== undefined || d.is_active !== undefined, {
+    message: 'Ange minst ett fält att uppdatera',
+  })
 
 // ============================================================
 // AI agent flow schemas

--- a/lib/salary/__tests__/calculation-engine.test.ts
+++ b/lib/salary/__tests__/calculation-engine.test.ts
@@ -132,6 +132,43 @@ describe('calculateSalary', () => {
     expect(result.grossSalary).toBe(40000) // 250 * 160
   })
 
+  it('uses hourlyBaseOverride for the base instead of rate × hours', () => {
+    // Per-day rate overrides: the caller pre-sums base pay across worked days
+    // (e.g. 80h @ 250 + 80h @ 300 = 44000) and passes it as the override. The
+    // engine must use that figure, not hourlyRate × hoursWorked (which would
+    // give the wrong 250 × 160 = 40000).
+    const result = calculateSalary(
+      makeBasicInput({
+        salaryType: 'hourly',
+        monthlySalary: 0,
+        hourlyRate: 250,
+        hoursWorked: 160,
+        hourlyBaseOverride: 44000,
+      }),
+      config2026,
+      emptyTaxRates
+    )
+
+    expect(result.grossSalary).toBe(44000)
+    expect(result.taxWithheld).toBe(13200) // 30% of 44000
+    expect(result.avgifterAmount).toBe(Math.round(44000 * 0.3142 * 100) / 100)
+  })
+
+  it('falls back to rate × hours when hourlyBaseOverride is omitted', () => {
+    const result = calculateSalary(
+      makeBasicInput({
+        salaryType: 'hourly',
+        monthlySalary: 0,
+        hourlyRate: 250,
+        hoursWorked: 160,
+      }),
+      config2026,
+      emptyTaxRates
+    )
+
+    expect(result.grossSalary).toBe(40000) // 250 * 160, unchanged behaviour
+  })
+
   it('applies sidoinkomst flat 30%', () => {
     const result = calculateSalary(
       makeBasicInput({ isSidoinkomst: true }),

--- a/lib/salary/calculation-engine.ts
+++ b/lib/salary/calculation-engine.ts
@@ -15,6 +15,13 @@ export interface SalaryCalculationInput {
   monthlySalary: number
   hourlyRate?: number
   hoursWorked?: number
+  /**
+   * Precomputed base pay for hourly employees, summed per worked day so that
+   * per-day hourly_rate overrides are honoured (Σ hours × effective rate).
+   * When provided, it replaces the `hourlyRate × hoursWorked` derivation. When
+   * omitted, the engine falls back to that product (unchanged behaviour).
+   */
+  hourlyBaseOverride?: number
   employmentDegree: number // 1-100
 
   /** Tax */
@@ -172,13 +179,25 @@ export function calculateSalary(
   } else {
     const hours = input.hoursWorked || 0
     const rate = input.hourlyRate || 0
-    baseSalary = r(rate * hours)
-    steps.push({
-      label: 'Grundlön (timavlönad)',
-      formula: 'timlön × arbetade timmar',
-      input: { hourly_rate: rate, hours_worked: hours },
-      output: baseSalary,
-    })
+    if (input.hourlyBaseOverride != null) {
+      // Per-day rate overrides: base was already summed per worked day, so a
+      // single timlön × timmar product would be wrong when rates differ.
+      baseSalary = r(input.hourlyBaseOverride)
+      steps.push({
+        label: 'Grundlön (timavlönad)',
+        formula: 'summa per dag (timlön × timmar)',
+        input: { hours_worked: hours },
+        output: baseSalary,
+      })
+    } else {
+      baseSalary = r(rate * hours)
+      steps.push({
+        label: 'Grundlön (timavlönad)',
+        formula: 'timlön × arbetade timmar',
+        input: { hourly_rate: rate, hours_worked: hours },
+        output: baseSalary,
+      })
+    }
   }
 
   // ─── Step 2: Add additions ───

--- a/lib/salary/run-calculation.ts
+++ b/lib/salary/run-calculation.ts
@@ -304,11 +304,16 @@ export async function runSalaryCalculation(
     //     For all employees (when premium rules exist), the same rows feed
     //     the shift-premium engine in 8z below.
     let derivedHoursWorked: number | null = null
-    let workedDayRows: Array<{ work_date: string; hours: number; start_time: string | null; end_time: string | null }> = []
+    // Weighted base pay (Σ hours × per-day-or-employee rate) for hourly
+    // employees whose hours come from the calendar. Null when hours fall back
+    // to the manual sre.hours_worked snapshot, so the engine keeps its
+    // rate × hours derivation in that legacy path.
+    let hourlyBaseAmount: number | null = null
+    let workedDayRows: Array<{ work_date: string; hours: number; hourly_rate: number | null; start_time: string | null; end_time: string | null }> = []
     if (emp.salary_type === 'hourly' || premiumRules.length > 0) {
       const { data: workedDays, error: workedError } = await supabase
         .from('salary_worked_days')
-        .select('hours, work_date, start_time, end_time')
+        .select('hours, hourly_rate, work_date, start_time, end_time')
         .eq('company_id', companyId)
         .eq('employee_id', emp.id)
         .gte('work_date', periodStart)
@@ -333,9 +338,28 @@ export async function runSalaryCalculation(
 
       // Refresh the hourly_salary line item so the displayed Lönerader table
       // matches what the engine actually calculated.
-      if (derivedHoursWorked > 0 && (emp.hourly_rate || 0) > 0) {
-        const baseAmount =
-          Math.round((emp.hourly_rate as number) * derivedHoursWorked * 100) / 100
+      //
+      // Each day is paid at its own hourly_rate override when set, otherwise
+      // the employee's default rate. We sum per-day pay so mixed rates stay
+      // exact; the line keeps total hours as quantity and the weighted sum as
+      // amount. With no overrides this reduces to rate × Σ hours — identical to
+      // the previous behaviour. (Shift premiums still use the employee base
+      // rate; per-day overrides only affect base hourly pay.)
+      const fallbackRate = emp.hourly_rate || 0
+      const baseAmount =
+        Math.round(
+          workedDayRows.reduce(
+            (sum, d) =>
+              sum +
+              Number(d.hours) *
+                (d.hourly_rate != null ? Number(d.hourly_rate) : fallbackRate),
+            0,
+          ) * 100,
+        ) / 100
+      // Hand the same figure to the engine so gross/tax/avgifter match the
+      // hourly_salary line item exactly (instead of recomputing rate × hours).
+      hourlyBaseAmount = baseAmount
+      if (derivedHoursWorked > 0 && baseAmount > 0) {
         await supabase
           .from('salary_line_items')
           .delete()
@@ -581,6 +605,7 @@ export async function runSalaryCalculation(
           derivedHoursWorked !== null && derivedHoursWorked > 0
             ? derivedHoursWorked
             : sre.hours_worked || undefined,
+        hourlyBaseOverride: hourlyBaseAmount ?? undefined,
         employmentDegree: emp.employment_degree,
         taxTableNumber: emp.tax_table_number,
         taxColumn: emp.tax_column || 1,

--- a/lib/salary/run-calculation.ts
+++ b/lib/salary/run-calculation.ts
@@ -358,7 +358,12 @@ export async function runSalaryCalculation(
         ) / 100
       // Hand the same figure to the engine so gross/tax/avgifter match the
       // hourly_salary line item exactly (instead of recomputing rate × hours).
-      hourlyBaseAmount = baseAmount
+      // Only when there are calendar rows: an empty reduce yields 0, and
+      // `0 ?? undefined` is 0, which would override the engine base to 0 and
+      // wipe out the manual sre.hours_worked fallback path.
+      if (workedDayRows.length > 0) {
+        hourlyBaseAmount = baseAmount
+      }
       if (derivedHoursWorked > 0 && baseAmount > 0) {
         await supabase
           .from('salary_line_items')

--- a/messages/en.json
+++ b/messages/en.json
@@ -1230,6 +1230,26 @@
     "latest_number": "Latest no.",
     "footnote": "New series are created automatically the first time they are used in bookkeeping."
   },
+  "settings_cost_centers": {
+    "heading": "Cost centers",
+    "description": "Reusable cost centers for allocating e.g. worked hours. Active cost centers can be selected in the salary calendar.",
+    "code_label": "Code",
+    "code_placeholder": "e.g. 100",
+    "name_label": "Name",
+    "name_placeholder": "e.g. Sales",
+    "add": "Add",
+    "empty_state": "No cost centers yet. Add one above to be able to select it in the salary calendar.",
+    "inactive_badge": "inactive",
+    "rename": "Rename",
+    "deactivate": "Deactivate",
+    "activate": "Activate",
+    "delete": "Delete",
+    "save": "Save",
+    "cancel": "Cancel",
+    "delete_confirm": "Delete cost center {code} · {name}? Existing entries keep their history but lose the link.",
+    "load_error": "Could not load cost centers",
+    "save_error": "Could not save"
+  },
   "settings_team_panel": {
     "role_owner": "Owner",
     "role_admin": "Admin",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -1230,6 +1230,26 @@
     "latest_number": "Senaste nr",
     "footnote": "Nya serier skapas automatiskt första gången de används vid bokföring."
   },
+  "settings_cost_centers": {
+    "heading": "Kostnadsställen",
+    "description": "Återanvändbara kostnadsställen för att fördela t.ex. arbetad tid. Aktiva kostnadsställen kan väljas i lönekalendern.",
+    "code_label": "Kod",
+    "code_placeholder": "t.ex. 100",
+    "name_label": "Namn",
+    "name_placeholder": "t.ex. Försäljning",
+    "add": "Lägg till",
+    "empty_state": "Inga kostnadsställen ännu. Lägg till ett ovan för att kunna välja det i lönekalendern.",
+    "inactive_badge": "inaktivt",
+    "rename": "Byt namn",
+    "deactivate": "Inaktivera",
+    "activate": "Aktivera",
+    "delete": "Ta bort",
+    "save": "Spara",
+    "cancel": "Avbryt",
+    "delete_confirm": "Ta bort kostnadsstället {code} · {name}? Befintliga registreringar behåller sin historik men förlorar kopplingen.",
+    "load_error": "Kunde inte ladda kostnadsställen",
+    "save_error": "Kunde inte spara"
+  },
   "settings_team_panel": {
     "role_owner": "Ägare",
     "role_admin": "Admin",

--- a/supabase/migrations/20260529120000_salary_worked_days_cost_center.sql
+++ b/supabase/migrations/20260529120000_salary_worked_days_cost_center.sql
@@ -1,0 +1,20 @@
+-- Migration: salary_worked_days_cost_center — optional cost-center tagging on
+-- manually-entered worked days.
+--
+-- Why this exists: when entering worked hours via the salary calendar, users
+-- want to attribute the time to a cost center (kostnadsställe) for later
+-- reporting. This stores the dimension on the day record only — it does not
+-- yet flow into salary line items or the booked journal entry.
+--
+-- Nullable + ON DELETE SET NULL: tagging is optional, and deactivating/removing
+-- a cost center must not block deletion or orphan the worked day.
+
+ALTER TABLE public.salary_worked_days
+  ADD COLUMN cost_center_id UUID REFERENCES cost_centers(id) ON DELETE SET NULL;
+
+-- Tagged-day lookups (e.g. "all worked days for cost center X").
+CREATE INDEX idx_salary_worked_days_cost_center
+  ON public.salary_worked_days (cost_center_id)
+  WHERE cost_center_id IS NOT NULL;
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/20260529130000_salary_worked_days_hourly_rate.sql
+++ b/supabase/migrations/20260529130000_salary_worked_days_hourly_rate.sql
@@ -1,0 +1,18 @@
+-- Migration: salary_worked_days_hourly_rate — optional per-day hourly wage
+-- override on manually-entered worked days.
+--
+-- Why this exists: the payroll calculator derives an hourly employee's base
+-- salary as `hourly_rate × Σ hours`, using the single rate stored on the
+-- employee record. Some shifts are paid at a different rate (e.g. a one-off
+-- higher rate, a stand-in covering another role). This lets the user set the
+-- rate to pay out per worked-day entry from the salary calendar.
+--
+-- Nullable by design: when null, the calculator falls back to the employee's
+-- default hourly_rate, so existing rows and the common case are unchanged.
+-- The CHECK mirrors the employee rate domain (non-negative monetary value).
+
+ALTER TABLE public.salary_worked_days
+  ADD COLUMN hourly_rate NUMERIC(10, 2)
+    CHECK (hourly_rate IS NULL OR hourly_rate >= 0);
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## What & why
Hourly employees need (1) to attribute worked time to a cost center and
(2) to be paid a different rate on specific days. Both are entered from the
existing salary-calendar "Arbetade timmar" dialog. Adds a settings page to
manage cost centers (the picker needs somewhere to source them).

## Changes
- Migrations: nullable `cost_center_id` (FK, ON DELETE SET NULL) and
  `hourly_rate` (NUMERIC, CHECK >= 0) on `salary_worked_days`.
- `/api/cost-centers` CRUD + `CostCenterManager` settings UI.
- Worked-hours routes/schemas carry `cost_center_id` + `hourly_rate`.
- `SalaryCalendar` worked-hours dialog: cost-center picker + hourly-rate field.
- Payroll engine: optional `hourlyBaseOverride` so gross/tax/avgifter/net match
  the per-day rates; `run-calculation` computes the weighted base once.
- Engine unit tests for the override path.

## Checks
- `npm run lint` clean for changed files; `npm test` 4641 passing; `npm run build` OK.

## Notes
- Shift/OB premiums still use the employee's default rate (separate decision).
- Run the new migrations before deploying.
