### PR TITLE
feat(salary): table-based time entry for salary runs

### DIFF
--- a/app/(dashboard)/salary/runs/[id]/page.tsx
+++ b/app/(dashboard)/salary/runs/[id]/page.tsx
@@ -11,7 +11,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import {
   ArrowLeft, Calculator, Eye, Check, CreditCard, BookOpen,
-  ArrowLeftCircle, Loader2, Download,
+  ArrowLeftCircle, Loader2, Download, Clock, ChevronDown,
 } from 'lucide-react'
 import { useToast } from '@/components/ui/use-toast'
 import { useCanWrite } from '@/lib/hooks/use-can-write'
@@ -71,6 +71,7 @@ export default function SalaryRunDetailPage({ params }: { params: Promise<{ id: 
     tax_payment_file_generated_at: string | null
     tax_paid_at: string | null
   } | null>(null)
+  const [showBreakdown, setShowBreakdown] = useState(false)
 
   async function loadRun() {
     const res = await fetch(`/api/salary/runs/${id}`)
@@ -273,24 +274,33 @@ export default function SalaryRunDetailPage({ params }: { params: Promise<{ id: 
       <Card>
         <CardHeader className="flex flex-row items-center justify-between">
           <CardTitle className="text-base">Anställda ({employees.length})</CardTitle>
-          {run.status === 'draft' && canWrite && notAdded.length > 0 && (
-            <Select
-              key={addEmployeeKey}
-              onValueChange={(value) => {
-                handleAddEmployee(value)
-                setAddEmployeeKey(k => k + 1)
-              }}
-            >
-              <SelectTrigger className="w-[200px] h-8 text-sm">
-                <SelectValue placeholder="Lägg till anställd..." />
-              </SelectTrigger>
-              <SelectContent>
-                {notAdded.map(emp => (
-                  <SelectItem key={emp.id} value={emp.id}>{emp.first_name} {emp.last_name}</SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          )}
+          <div className="flex items-center gap-2">
+            {employees.length > 0 && canWrite && (run.status === 'draft' || run.status === 'review') && (
+              <Button asChild variant="outline" size="sm" className="h-8">
+                <Link href={`/salary/runs/${id}/time-entry`}>
+                  <Clock className="mr-1 h-3.5 w-3.5" /> Registrera tid
+                </Link>
+              </Button>
+            )}
+            {run.status === 'draft' && canWrite && notAdded.length > 0 && (
+              <Select
+                key={addEmployeeKey}
+                onValueChange={(value) => {
+                  handleAddEmployee(value)
+                  setAddEmployeeKey(k => k + 1)
+                }}
+              >
+                <SelectTrigger className="w-[200px] h-8 text-sm">
+                  <SelectValue placeholder="Lägg till anställd..." />
+                </SelectTrigger>
+                <SelectContent>
+                  {notAdded.map(emp => (
+                    <SelectItem key={emp.id} value={emp.id}>{emp.first_name} {emp.last_name}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+          </div>
         </CardHeader>
         <CardContent className="p-0">
           {employees.length === 0 ? (
@@ -351,8 +361,19 @@ export default function SalaryRunDetailPage({ params }: { params: Promise<{ id: 
       {employees.some(e => e.calculation_breakdown) && (
         <Card>
           <CardHeader>
-            <CardTitle className="text-base">Beräkningsdetaljer</CardTitle>
+            <button
+              type="button"
+              onClick={() => setShowBreakdown(v => !v)}
+              aria-expanded={showBreakdown}
+              className="flex w-full items-center justify-between text-left"
+            >
+              <CardTitle className="text-base">Beräkningsdetaljer</CardTitle>
+              <ChevronDown
+                className={`h-4 w-4 text-muted-foreground transition-transform ${showBreakdown ? 'rotate-180' : ''}`}
+              />
+            </button>
           </CardHeader>
+          {showBreakdown && (
           <CardContent className="space-y-4">
             <TaxTableStatus year={run.period_year} compact />
             {employees.filter(e => e.calculation_breakdown).map(sre => {
@@ -380,6 +401,7 @@ export default function SalaryRunDetailPage({ params }: { params: Promise<{ id: 
               )
             })}
           </CardContent>
+          )}
         </Card>
       )}
 

--- a/app/(dashboard)/salary/runs/[id]/time-entry/page.tsx
+++ b/app/(dashboard)/salary/runs/[id]/time-entry/page.tsx
@@ -4,6 +4,7 @@ import { use, useCallback, useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
 import { ArrowLeft, Loader2 } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { PageHeader } from '@/components/ui/page-header'
 import { useToast } from '@/components/ui/use-toast'
 import { useCanWrite } from '@/lib/hooks/use-can-write'
 import { BulkTimeEntryTable, type RunEmployeeOption, type ExistingTimeEntry } from '@/components/salary/BulkTimeEntryTable'
@@ -100,8 +101,8 @@ export default function SalaryRunTimeEntryPage({ params }: { params: Promise<{ i
     })
   }, [run])
 
-  // Tid kan bara registreras medan körningen är redigerbar. Efter godkännande
-  // är raderna låsta (samma regel som kalendervyn per anställd).
+  // Time can only be registered while the run is editable. After approval the
+  // rows are locked (same rule as the per-employee calendar view).
   const readOnly = !canWrite || (run != null && run.status !== 'draft' && run.status !== 'review')
 
   if (loading) {
@@ -129,16 +130,13 @@ export default function SalaryRunTimeEntryPage({ params }: { params: Promise<{ i
 
   return (
     <div className="space-y-6">
-      <div className="space-y-2">
-        <Link href={`/salary/runs/${id}`} className="inline-flex items-center text-sm text-muted-foreground hover:underline">
-          <ArrowLeft className="mr-1 h-3.5 w-3.5" /> Tillbaka till lönekörning
-        </Link>
-        <h1 className="font-display text-3xl tracking-tight md:text-4xl">Registrera tid</h1>
-        <p className="text-sm text-muted-foreground">
-          Lägg till arbetade timmar och frånvaro för perioden {periodLabel} i en tabell — ett alternativ
-          till kalendern per anställd. Varje rad sparas mot vald anställd i den här lönekörningen.
-        </p>
-      </div>
+      <Link href={`/salary/runs/${id}`} className="inline-flex items-center text-sm text-muted-foreground hover:underline">
+        <ArrowLeft className="mr-1 h-3.5 w-3.5" /> Tillbaka till lönekörning
+      </Link>
+      <PageHeader
+        title="Registrera tid"
+        description={`Lägg till arbetade timmar och frånvaro för perioden ${periodLabel} i en tabell — ett alternativ till kalendern per anställd. Varje rad sparas mot vald anställd i den här lönekörningen.`}
+      />
 
       {readOnly && (
         <div className="rounded-md border border-warning/30 bg-warning/10 p-3 text-sm text-warning-foreground">

--- a/app/(dashboard)/salary/runs/[id]/time-entry/page.tsx
+++ b/app/(dashboard)/salary/runs/[id]/time-entry/page.tsx
@@ -1,0 +1,176 @@
+'use client'
+
+import { use, useCallback, useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
+import { ArrowLeft, Loader2 } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { useToast } from '@/components/ui/use-toast'
+import { useCanWrite } from '@/lib/hooks/use-can-write'
+import { BulkTimeEntryTable, type RunEmployeeOption, type ExistingTimeEntry } from '@/components/salary/BulkTimeEntryTable'
+import type { SalaryRun, SalaryRunEmployee, Employee } from '@/types'
+
+export default function SalaryRunTimeEntryPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params)
+  const { toast } = useToast()
+  const { canWrite } = useCanWrite()
+  const [run, setRun] = useState<SalaryRun | null>(null)
+  const [entries, setEntries] = useState<ExistingTimeEntry[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch(`/api/salary/runs/${id}`)
+      const json = await res.json()
+      if (!res.ok) throw new Error(json.error || 'Kunde inte ladda lönekörningen')
+      const runData = json.data as SalaryRun
+      setRun(runData)
+
+      // Pull every worked-day + absence-day already saved for the period so the
+      // table can show (and edit) them. One pair of requests per employee, run
+      // in parallel.
+      const y = runData.period_year
+      const m = runData.period_month
+      const from = `${y}-${String(m).padStart(2, '0')}-01`
+      const lastDay = new Date(Date.UTC(y, m, 0)).getUTCDate()
+      const to = `${y}-${String(m).padStart(2, '0')}-${String(lastDay).padStart(2, '0')}`
+
+      const list = (runData.employees ?? []) as SalaryRunEmployee[]
+      const order = new Map(list.map((s, i) => [s.employee_id, i]))
+      const collected: ExistingTimeEntry[] = []
+
+      await Promise.all(list.map(async (sre) => {
+        const empId = sre.employee_id
+        const [wRes, aRes] = await Promise.all([
+          fetch(`/api/salary/employees/${empId}/worked-hours?from=${from}&to=${to}`),
+          fetch(`/api/salary/employees/${empId}/absence?from=${from}&to=${to}`),
+        ])
+        if (wRes.ok) {
+          const wj = await wRes.json()
+          for (const d of (wj.data ?? [])) {
+            collected.push({ employeeId: empId, kind: 'worked', date: d.work_date, hours: Number(d.hours), notes: d.notes ?? null })
+          }
+        }
+        if (aRes.ok) {
+          const aj = await aRes.json()
+          for (const d of (aj.data ?? [])) {
+            collected.push({ employeeId: empId, kind: d.absence_type, date: d.absence_date, hours: Number(d.hours), notes: d.notes ?? null })
+          }
+        }
+      }))
+
+      collected.sort((a, b) =>
+        (order.get(a.employeeId)! - order.get(b.employeeId)!) || a.date.localeCompare(b.date))
+      setEntries(collected)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Okänt fel')
+    } finally {
+      setLoading(false)
+    }
+  }, [id])
+
+  useEffect(() => { load() }, [load])
+
+  const periodStart = useMemo(() => {
+    if (!run) return ''
+    return `${run.period_year}-${String(run.period_month).padStart(2, '0')}-01`
+  }, [run])
+
+  const periodEnd = useMemo(() => {
+    if (!run) return ''
+    const last = new Date(Date.UTC(run.period_year, run.period_month, 0)).getUTCDate()
+    return `${run.period_year}-${String(run.period_month).padStart(2, '0')}-${String(last).padStart(2, '0')}`
+  }, [run])
+
+  const employees = useMemo<RunEmployeeOption[]>(() => {
+    const list = (run?.employees ?? []) as SalaryRunEmployee[]
+    return list.map(sre => {
+      const emp = sre.employee as (Employee & { personnummer_last4?: string | null }) | undefined
+      const name = emp ? `${emp.first_name} ${emp.last_name}` : `Anställd ${sre.employee_id.slice(0, 8)}…`
+      return {
+        sreId: sre.id,
+        employeeId: sre.employee_id,
+        name,
+        salaryType: sre.salary_type,
+        personnummer: emp?.personnummer ?? null,
+        personnummerLast4: emp?.personnummer_last4 ?? null,
+      }
+    })
+  }, [run])
+
+  // Tid kan bara registreras medan körningen är redigerbar. Efter godkännande
+  // är raderna låsta (samma regel som kalendervyn per anställd).
+  const readOnly = !canWrite || (run != null && run.status !== 'draft' && run.status !== 'review')
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12 text-muted-foreground">
+        <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Laddar…
+      </div>
+    )
+  }
+
+  if (error || !run) {
+    return (
+      <div className="space-y-3">
+        <Link href={`/salary/runs/${id}`} className="inline-flex items-center text-sm text-muted-foreground hover:underline">
+          <ArrowLeft className="mr-1 h-3.5 w-3.5" /> Tillbaka till lönekörning
+        </Link>
+        <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+          {error ?? 'Kunde inte ladda lönekörningen'}
+        </div>
+      </div>
+    )
+  }
+
+  const periodLabel = `${run.period_year}-${String(run.period_month).padStart(2, '0')}`
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <Link href={`/salary/runs/${id}`} className="inline-flex items-center text-sm text-muted-foreground hover:underline">
+          <ArrowLeft className="mr-1 h-3.5 w-3.5" /> Tillbaka till lönekörning
+        </Link>
+        <h1 className="font-display text-3xl tracking-tight md:text-4xl">Registrera tid</h1>
+        <p className="text-sm text-muted-foreground">
+          Lägg till arbetade timmar och frånvaro för perioden {periodLabel} i en tabell — ett alternativ
+          till kalendern per anställd. Varje rad sparas mot vald anställd i den här lönekörningen.
+        </p>
+      </div>
+
+      {readOnly && (
+        <div className="rounded-md border border-warning/30 bg-warning/10 p-3 text-sm text-warning-foreground">
+          {canWrite
+            ? 'Lönekörningen är inte längre ett utkast — tid kan inte registreras.'
+            : 'Du har skrivskyddad åtkomst till det här företaget.'}
+        </div>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Tidrader</CardTitle>
+          <p className="text-xs text-muted-foreground">
+            Redan registrerad tid för perioden visas nedan och kan ändras eller tas bort. Arbetad tid
+            gäller endast timavlönade; frånvaro (sjukdom, VAB, föräldraledighet m.m.) gäller alla.
+            Befintlig tid för samma anställd och dag skrivs över; kombinationen får inte överstiga
+            24 timmar per dag.
+          </p>
+        </CardHeader>
+        <CardContent>
+          <BulkTimeEntryTable
+            periodStart={periodStart}
+            periodEnd={periodEnd}
+            employees={employees}
+            initialEntries={entries}
+            readOnly={readOnly}
+            onChanged={() => {
+              toast({ title: 'Tid uppdaterad', description: 'Räkna om lönekörningen för att uppdatera beloppen.' })
+            }}
+          />
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/components/salary/BulkTimeEntryTable.tsx
+++ b/components/salary/BulkTimeEntryTable.tsx
@@ -1,0 +1,551 @@
+'use client'
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Plus, Trash2, Loader2, Check, AlertTriangle } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { parseHoursInput } from '@/lib/salary/parse-hours'
+
+export interface RunEmployeeOption {
+  /** salary_run_employees.id — links the new rows to this run. */
+  sreId: string
+  employeeId: string
+  name: string
+  salaryType: string
+  /** Masked personnummer for display (e.g. 19900101-XXXX). */
+  personnummer?: string | null
+  /** Last 4 digits, used for search matching. */
+  personnummerLast4?: string | null
+}
+
+/** An already-saved worked-day / absence-day row for the period. */
+export interface ExistingTimeEntry {
+  employeeId: string
+  /** WORKED sentinel or an absence type. */
+  kind: string
+  date: string
+  hours: number
+  notes: string | null
+}
+
+interface BulkTimeEntryTableProps {
+  periodStart: string
+  periodEnd: string
+  employees: RunEmployeeOption[]
+  /** Worked + absence rows already saved for the period, pre-loaded for editing. */
+  initialEntries?: ExistingTimeEntry[]
+  /** Disable all editing (e.g. once the run is approved/booked). */
+  readOnly?: boolean
+  /** Called after a save or delete changed server state, so the parent can refresh totals. */
+  onChanged?: () => void
+}
+
+// Worked-time sentinel vs the absence types. Worked hours only apply to hourly
+// employees; absence applies to everyone.
+const WORKED = 'worked'
+
+const ABSENCE_TYPES: { value: string; label: string }[] = [
+  { value: 'sick', label: 'Sjukdom' },
+  { value: 'vab', label: 'VAB' },
+  { value: 'parental', label: 'Föräldraledig' },
+  { value: 'pregnancy', label: 'Graviditetspenning' },
+  { value: 'care_relative', label: 'Närståendepenning' },
+  { value: 'study', label: 'Studieledig' },
+  { value: 'other_leave', label: 'Övrig ledighet' },
+]
+
+type RowStatus = 'idle' | 'saving' | 'saved' | 'error' | 'conflict'
+
+/** The natural key of a saved record, used to overwrite/delete the right row. */
+interface RowSnapshot {
+  employeeId: string
+  date: string
+  kind: string
+  hours: string
+  notes: string
+}
+
+interface EntryRow {
+  key: string
+  origin: 'new' | 'existing'
+  /** Snapshot of the saved record (for existing rows) so edits to the natural
+   *  key can delete the old record before writing the new one. */
+  original?: RowSnapshot
+  employeeId: string
+  kind: string
+  date: string
+  hours: string
+  notes: string
+  status: RowStatus
+  message?: string
+}
+
+export function BulkTimeEntryTable({
+  periodStart,
+  periodEnd,
+  employees,
+  initialEntries,
+  readOnly = false,
+  onChanged,
+}: BulkTimeEntryTableProps) {
+  const rowSeq = useRef(0)
+  const nextKey = () => `r${rowSeq.current++}`
+
+  const blankRow = (): EntryRow => ({
+    key: nextKey(),
+    origin: 'new',
+    employeeId: '',
+    kind: '',
+    date: periodStart,
+    hours: '8',
+    notes: '',
+    status: 'idle',
+  })
+
+  // Build the initial row set from existing entries (editable). Only when there
+  // are none do we seed a single blank row to start from — otherwise the user
+  // adds rows explicitly via "Lägg till rad". Runs once — the parent gates
+  // rendering until entries are loaded, so this initializer sees the full list.
+  // Static keys here (no ref reads during render); addRow uses nextKey() with
+  // its own prefix so there's no collision.
+  const [rows, setRows] = useState<EntryRow[]>(() => {
+    const existing: EntryRow[] = (initialEntries ?? []).map((e, i) => {
+      const hours = String(e.hours)
+      const notes = e.notes ?? ''
+      return {
+        key: `e${i}`,
+        origin: 'existing' as const,
+        original: { employeeId: e.employeeId, date: e.date, kind: e.kind, hours, notes },
+        employeeId: e.employeeId,
+        kind: e.kind,
+        date: e.date,
+        hours,
+        notes,
+        status: 'idle' as RowStatus,
+      }
+    })
+    if (existing.length > 0) return existing
+    // No saved entries yet — start with one blank row.
+    const blank: EntryRow = {
+      key: 'new0',
+      origin: 'new',
+      employeeId: '',
+      kind: '',
+      date: periodStart,
+      hours: '8',
+      notes: '',
+      status: 'idle',
+    }
+    return [blank]
+  })
+  const [submitting, setSubmitting] = useState(false)
+
+  const employeeById = useMemo(() => {
+    const m = new Map<string, RunEmployeeOption>()
+    for (const e of employees) m.set(e.employeeId, e)
+    return m
+  }, [employees])
+
+  // Worked time is only offered for hourly employees; everyone can take absence.
+  const kindOptionsFor = (employeeId: string): { value: string; label: string }[] => {
+    const emp = employeeById.get(employeeId)
+    const base = emp && emp.salaryType === 'hourly'
+      ? [{ value: WORKED, label: 'Arbetad tid' }]
+      : []
+    return [...base, ...ABSENCE_TYPES]
+  }
+
+  const update = (key: string, patch: Partial<EntryRow>) => {
+    setRows(prev => prev.map(r => (r.key === key ? { ...r, ...patch, status: 'idle', message: undefined } : r)))
+  }
+
+  const onEmployeeChange = (key: string, employeeId: string) => {
+    setRows(prev => prev.map(r => {
+      if (r.key !== key) return r
+      // Reset a now-invalid kind (e.g. switched to a monthly employee while
+      // "Arbetad tid" was selected).
+      const allowed = kindOptionsFor(employeeId).map(o => o.value)
+      const kind = allowed.includes(r.kind) ? r.kind : ''
+      return { ...r, employeeId, kind, status: 'idle', message: undefined }
+    }))
+  }
+
+  const addRow = () => setRows(prev => [...prev, blankRow()])
+
+  const validateRow = (r: EntryRow): string | null => {
+    if (!r.employeeId) return 'Välj anställd'
+    if (!r.kind) return 'Välj typ'
+    if (!r.date || r.date < periodStart || r.date > periodEnd) return 'Datum utanför perioden'
+    const h = parseHoursInput(r.hours)
+    if (h == null || h <= 0 || h > 24) return 'Timmar måste vara mellan 0 och 24'
+    return null
+  }
+
+  const isBlankNew = (r: EntryRow) => r.origin === 'new' && !r.employeeId && !r.kind
+  const isDirty = (r: EntryRow) => {
+    if (r.origin === 'new') return !isBlankNew(r)
+    const o = r.original
+    if (!o) return true
+    return o.employeeId !== r.employeeId || o.date !== r.date || o.kind !== r.kind
+      || o.hours !== r.hours || o.notes !== r.notes
+  }
+
+  const keyChanged = (r: EntryRow) =>
+    !!r.original && (r.original.employeeId !== r.employeeId || r.original.date !== r.date || r.original.kind !== r.kind)
+
+  // Delete a saved record by its natural key.
+  const deleteEntry = async (employeeId: string, kind: string, date: string): Promise<{ ok: boolean; message?: string }> => {
+    const url = kind === WORKED
+      ? `/api/salary/employees/${employeeId}/worked-hours?date=${date}`
+      : `/api/salary/employees/${employeeId}/absence?date=${date}&type=${kind}`
+    try {
+      const res = await fetch(url, { method: 'DELETE' })
+      if (res.ok) return { ok: true }
+      const json = await res.json().catch(() => ({}))
+      return { ok: false, message: json.error || 'Kunde inte ta bort befintlig rad' }
+    } catch {
+      return { ok: false, message: 'Nätverksfel' }
+    }
+  }
+
+  const postEntry = async (r: EntryRow, hours: number, sreId: string): Promise<{ status: RowStatus; message?: string }> => {
+    try {
+      const res = r.kind === WORKED
+        ? await fetch(`/api/salary/employees/${r.employeeId}/worked-hours`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ work_date: r.date, hours, notes: r.notes.trim() || undefined, salary_run_employee_id: sreId }),
+          })
+        : await fetch(`/api/salary/employees/${r.employeeId}/absence`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ absence_date: r.date, absence_type: r.kind, hours, notes: r.notes.trim() || undefined, salary_run_employee_id: sreId }),
+          })
+      if (res.ok) return { status: 'saved' }
+      const json = await res.json().catch(() => ({}))
+      // 409 = the 24h-per-day cap across worked + absence was exceeded.
+      if (res.status === 409) return { status: 'conflict', message: json.error || 'Överstiger 24 timmar för dagen' }
+      return { status: 'error', message: json.error || 'Kunde inte spara' }
+    } catch {
+      return { status: 'error', message: 'Nätverksfel' }
+    }
+  }
+
+  const saveRow = async (r: EntryRow): Promise<{ status: RowStatus; message?: string }> => {
+    const invalid = validateRow(r)
+    if (invalid) return { status: 'error', message: invalid }
+
+    const emp = employeeById.get(r.employeeId)
+    if (!emp) return { status: 'error', message: 'Okänd anställd' }
+    const hours = parseHoursInput(r.hours)
+    if (hours == null) return { status: 'error', message: 'Ogiltiga timmar' }
+
+    // If the natural key moved, remove the old record first so we don't leave
+    // an orphan at the previous employee/date/type.
+    if (keyChanged(r) && r.original) {
+      const del = await deleteEntry(r.original.employeeId, r.original.kind, r.original.date)
+      if (!del.ok) return { status: 'error', message: del.message }
+    }
+
+    return postEntry(r, hours, emp.sreId)
+  }
+
+  const handleSaveAll = async () => {
+    setSubmitting(true)
+    let changed = 0
+    // Sequential so per-row conflicts surface against the right row and the
+    // 24h-cap trigger sees a consistent picture as rows land.
+    for (const r of rows) {
+      if (isBlankNew(r)) continue
+      if (r.origin === 'existing' && !isDirty(r)) continue
+      setRows(prev => prev.map(x => (x.key === r.key ? { ...x, status: 'saving', message: undefined } : x)))
+      const result = await saveRow(r)
+      if (result.status === 'saved') {
+        changed++
+        // Re-snapshot so a second save is an in-place overwrite, not a duplicate.
+        setRows(prev => prev.map(x => (x.key === r.key
+          ? { ...x, status: 'saved', message: undefined, origin: 'existing',
+              original: { employeeId: x.employeeId, date: x.date, kind: x.kind, hours: x.hours, notes: x.notes } }
+          : x)))
+      } else {
+        setRows(prev => prev.map(x => (x.key === r.key ? { ...x, status: result.status, message: result.message } : x)))
+      }
+    }
+    setSubmitting(false)
+    if (changed > 0) onChanged?.()
+  }
+
+  const handleRemove = async (r: EntryRow) => {
+    // New, never-saved rows are removed locally. Existing rows delete the saved
+    // record first.
+    if (r.origin === 'new') {
+      setRows(prev => prev.filter(x => x.key !== r.key))
+      return
+    }
+    const o = r.original ?? { employeeId: r.employeeId, kind: r.kind, date: r.date }
+    setRows(prev => prev.map(x => (x.key === r.key ? { ...x, status: 'saving', message: undefined } : x)))
+    const del = await deleteEntry(o.employeeId, o.kind, o.date)
+    if (del.ok) {
+      setRows(prev => prev.filter(x => x.key !== r.key))
+      onChanged?.()
+    } else {
+      setRows(prev => prev.map(x => (x.key === r.key ? { ...x, status: 'error', message: del.message } : x)))
+    }
+  }
+
+  const savedRows = rows.filter(r => r.status === 'saved').length
+  const problemRows = rows.filter(r => r.status === 'error' || r.status === 'conflict').length
+
+  if (employees.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Lägg till anställda i lönekörningen först, så kan du registrera tid här.
+      </p>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Raw table (not the Table primitive) so the employee combobox dropdown
+          isn't clipped by the primitive's overflow-auto wrapper. border-collapse
+          so the per-row border-b dividers paint as clean full-width lines. */}
+      <table className="w-full border-collapse text-sm">
+        <thead className="[&_th]:font-medium [&_th]:text-[11px] [&_th]:uppercase [&_th]:tracking-wider [&_th]:text-muted-foreground">
+          <tr className="border-b text-left">
+            <th className="py-2 pr-2 min-w-[200px]">Anställd</th>
+            <th className="py-2 px-2 min-w-[150px]">Typ</th>
+            <th className="py-2 px-2 w-40">Datum</th>
+            <th className="py-2 px-2 w-36">Timmar</th>
+            <th className="py-2 px-2 min-w-[140px]">Anteckning</th>
+            <th className="py-2 px-2 w-24">Status</th>
+            <th className="py-2 w-10" />
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map(r => {
+            const kindOptions = kindOptionsFor(r.employeeId)
+            return (
+              <tr key={r.key} className="border-b align-top">
+                <td className="py-1.5 pr-2">
+                  <EmployeeCombobox
+                    value={r.employeeId}
+                    employees={employees}
+                    onChange={(id) => onEmployeeChange(r.key, id)}
+                    disabled={readOnly || submitting}
+                  />
+                </td>
+                <td className="py-1.5 px-2">
+                  <Select
+                    value={r.kind}
+                    onValueChange={(v) => update(r.key, { kind: v })}
+                    disabled={readOnly || submitting || !r.employeeId}
+                  >
+                    <SelectTrigger className="h-8"><SelectValue placeholder="Välj typ" /></SelectTrigger>
+                    <SelectContent>
+                      {kindOptions.map(o => (
+                        <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </td>
+                <td className="py-1.5 px-2">
+                  <Input
+                    type="date"
+                    value={r.date}
+                    min={periodStart}
+                    max={periodEnd}
+                    onChange={(e) => update(r.key, { date: e.target.value })}
+                    disabled={readOnly || submitting}
+                    className="h-8 tabular-nums"
+                  />
+                </td>
+                <td className="py-1.5 px-2">
+                  <Input
+                    type="text"
+                    value={r.hours}
+                    onChange={(e) => update(r.key, { hours: e.target.value })}
+                    disabled={readOnly || submitting}
+                    placeholder="8 el. 1740-2240"
+                    className="h-8 tabular-nums"
+                  />
+                  {(() => {
+                    // Show the computed hours when a time range was typed.
+                    if (!/[-–—]/.test(r.hours)) return null
+                    const parsed = parseHoursInput(r.hours)
+                    return (
+                      <div className={cn('mt-0.5 text-[11px] tabular-nums', parsed == null ? 'text-destructive' : 'text-muted-foreground')}>
+                        {parsed == null ? 'Ogiltigt intervall' : `= ${parsed} tim`}
+                      </div>
+                    )
+                  })()}
+                </td>
+                <td className="py-1.5 px-2">
+                  <Input
+                    value={r.notes}
+                    maxLength={2000}
+                    onChange={(e) => update(r.key, { notes: e.target.value })}
+                    disabled={readOnly || submitting}
+                    className="h-8"
+                    placeholder="Valfri"
+                  />
+                </td>
+                <td className="py-1.5 px-2">
+                  <RowStatusCell status={r.status} message={r.message} />
+                </td>
+                <td className="py-1.5">
+                  {!readOnly && (rows.length > 1 || r.origin === 'existing') && (
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8"
+                      onClick={() => handleRemove(r)}
+                      disabled={submitting}
+                      aria-label="Ta bort rad"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </Button>
+                  )}
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+
+      {problemRows > 0 && (
+        <ul className="space-y-1 rounded-md bg-destructive/10 px-3 py-2 text-xs text-destructive">
+          {rows.map((r, i) =>
+            (r.status === 'error' || r.status === 'conflict') && r.message ? (
+              <li key={r.key}>Rad {i + 1}: {r.message}</li>
+            ) : null,
+          )}
+        </ul>
+      )}
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <Button variant="outline" size="sm" onClick={addRow} disabled={readOnly || submitting}>
+          <Plus className="mr-1 h-4 w-4" /> Lägg till rad
+        </Button>
+        <div className="flex items-center gap-3">
+          {(savedRows > 0 || problemRows > 0) && (
+            <span className="text-xs text-muted-foreground tabular-nums">
+              {savedRows} sparade{problemRows > 0 ? `, ${problemRows} med fel` : ''}
+            </span>
+          )}
+          <Button onClick={handleSaveAll} disabled={readOnly || submitting}>
+            {submitting && <Loader2 className="mr-1 h-4 w-4 animate-spin" />}
+            Spara alla rader
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ─── Searchable employee picker ─────────────────────────────────────
+// Type a name or personnummer to filter. Mirrors the AccountCombobox pattern
+// (Input + absolutely-positioned dropdown) since the project has no shared
+// combobox/command primitive.
+function EmployeeCombobox({
+  value,
+  employees,
+  onChange,
+  disabled,
+}: {
+  value: string
+  employees: RunEmployeeOption[]
+  onChange: (employeeId: string) => void
+  disabled?: boolean
+}) {
+  const [open, setOpen] = useState(false)
+  const [search, setSearch] = useState('')
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const selected = employees.find(e => e.employeeId === value)
+
+  useEffect(() => {
+    function onDocMouseDown(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', onDocMouseDown)
+    return () => document.removeEventListener('mousedown', onDocMouseDown)
+  }, [])
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    if (!q) return employees
+    const digits = q.replace(/\D/g, '')
+    return employees.filter(e => {
+      if (e.name.toLowerCase().includes(q)) return true
+      if (digits.length === 0) return false
+      const last4 = (e.personnummerLast4 ?? '').replace(/\D/g, '')
+      const masked = (e.personnummer ?? '').replace(/\D/g, '')
+      return last4.includes(digits) || masked.includes(digits)
+    })
+  }, [employees, search])
+
+  return (
+    <div ref={containerRef} className="relative">
+      <Input
+        value={open ? search : (selected?.name ?? '')}
+        placeholder="Sök namn eller personnr"
+        disabled={disabled}
+        onFocus={() => { setOpen(true); setSearch('') }}
+        onChange={(e) => { setSearch(e.target.value); if (!open) setOpen(true) }}
+        className="h-8"
+      />
+      {open && !disabled && (
+        <div className="absolute z-50 mt-1 max-h-56 w-full min-w-[220px] overflow-auto rounded-md border border-border bg-background shadow-md">
+          {filtered.length === 0 ? (
+            <div className="px-3 py-2 text-xs text-muted-foreground">Inga träffar</div>
+          ) : (
+            filtered.map(e => (
+              <button
+                type="button"
+                key={e.employeeId}
+                onClick={() => { onChange(e.employeeId); setOpen(false); setSearch('') }}
+                className={cn(
+                  'flex w-full flex-col items-start px-3 py-1.5 text-left transition-colors hover:bg-secondary/60',
+                  e.employeeId === value && 'bg-secondary/40',
+                )}
+              >
+                <span className="text-sm">{e.name}</span>
+                {e.personnummer && (
+                  <span className="text-[11px] text-muted-foreground tabular-nums">{e.personnummer}</span>
+                )}
+              </button>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function RowStatusCell({ status, message }: { status: RowStatus; message?: string }) {
+  if (status === 'saving') {
+    return <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+  }
+  if (status === 'saved') {
+    return (
+      <span className="inline-flex items-center gap-1 text-xs text-success">
+        <Check className="h-3.5 w-3.5" /> Sparad
+      </span>
+    )
+  }
+  if (status === 'error' || status === 'conflict') {
+    // Keep the cell compact — the full message would crowd the row, so show a
+    // short label here (hover for detail) and list messages below the table.
+    return (
+      <span className="inline-flex items-center gap-1 text-xs text-destructive" title={message}>
+        <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+        {status === 'conflict' ? 'Konflikt' : 'Fel'}
+      </span>
+    )
+  }
+  return null
+}

--- a/lib/salary/__tests__/parse-hours.test.ts
+++ b/lib/salary/__tests__/parse-hours.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { parseHoursInput } from '../parse-hours'
+
+describe('parseHoursInput', () => {
+  it('parses plain numbers', () => {
+    expect(parseHoursInput('8')).toBe(8)
+    expect(parseHoursInput('6.5')).toBe(6.5)
+    expect(parseHoursInput('0')).toBe(0)
+  })
+
+  it('accepts Swedish decimal comma', () => {
+    expect(parseHoursInput('6,5')).toBe(6.5)
+  })
+
+  it('parses HHMM-HHMM ranges', () => {
+    expect(parseHoursInput('1740-2240')).toBe(5)
+    expect(parseHoursInput('0800-1630')).toBe(8.5)
+    expect(parseHoursInput('9-17')).toBe(8)
+  })
+
+  it('parses HH:MM-HH:MM ranges', () => {
+    expect(parseHoursInput('17:40-22:40')).toBe(5)
+    expect(parseHoursInput('08:00-16:30')).toBe(8.5)
+  })
+
+  it('handles overnight ranges by wrapping past midnight', () => {
+    // 17:40 → 00:30 next day = 6h50m = 6.83
+    expect(parseHoursInput('1740-0030')).toBe(6.83)
+    // 22:00 → 06:00 = 8h
+    expect(parseHoursInput('2200-0600')).toBe(8)
+  })
+
+  it('accepts en/em dashes', () => {
+    expect(parseHoursInput('0800–1630')).toBe(8.5)
+    expect(parseHoursInput('0800—1630')).toBe(8.5)
+  })
+
+  it('returns null for unparseable input', () => {
+    expect(parseHoursInput('')).toBeNull()
+    expect(parseHoursInput('abc')).toBeNull()
+    expect(parseHoursInput('1740-')).toBeNull()
+    expect(parseHoursInput('2540-2600')).toBeNull() // invalid clock hours
+    expect(parseHoursInput('0800-0800')).toBeNull() // zero-length
+  })
+
+  it('treats a negative number as a plain (invalid-downstream) value, not a range', () => {
+    expect(parseHoursInput('-5')).toBe(-5)
+  })
+
+  it('rounds to 2 decimals', () => {
+    // 17:40 → 00:35 = 6h55m = 6.9166… → 6.92
+    expect(parseHoursInput('1740-0035')).toBe(6.92)
+  })
+})

--- a/lib/salary/parse-hours.ts
+++ b/lib/salary/parse-hours.ts
@@ -1,0 +1,65 @@
+/**
+ * Parse a worked-hours input that is either a plain number or a clock-time
+ * range, returning hours as a decimal rounded to 2 dp (or null when it can't
+ * be parsed).
+ *
+ * Accepted forms:
+ *   - Plain number: "8", "6.5", "6,5" (Swedish decimal comma)
+ *   - Time range:   "1740-2240", "17:40-22:40", "9-17", "0800–1630" (en dash)
+ *
+ * Overnight ranges wrap: when the end is at or before the start it is treated
+ * as the next day, so "1740-0030" reads 00:30 as 24:30 → 6.83 h. The result is
+ * always < 24 h, matching the DB cap on salary_worked_days.hours.
+ */
+export function parseHoursInput(raw: string): number | null {
+  if (raw == null) return null
+  const s = String(raw).trim().replace(',', '.')
+  if (!s) return null
+
+  // A separator that isn't the leading char signals range intent ("1740-2240").
+  // A leading "-" is a negative number, not a range. Once we treat it as a
+  // range we never fall back to a plain number — a half-typed "1740-" is null,
+  // not 1740.
+  const sepIndex = s.search(/[-–—]/)
+  if (sepIndex > 0) {
+    const parts = s.split(/\s*[-–—]\s*/)
+    if (parts.length !== 2) return null
+    const start = parseClockToken(parts[0])
+    let end = parseClockToken(parts[1])
+    if (start == null || end == null) return null
+    if (end < start) end += 24 * 60 // overnight wrap
+    const minutes = end - start
+    if (minutes <= 0) return null
+    return Math.round((minutes / 60) * 100) / 100
+  }
+
+  const n = parseFloat(s)
+  if (!isFinite(n)) return null
+  return Math.round(n * 100) / 100
+}
+
+/** Parse a clock time to minutes-since-midnight. Returns null if invalid. */
+function parseClockToken(token: string): number | null {
+  const t = token.trim()
+  let h: number
+  let m: number
+
+  if (t.includes(':')) {
+    const [hh, mm = '0'] = t.split(':')
+    h = parseInt(hh, 10)
+    m = parseInt(mm, 10)
+  } else if (/^\d{3,4}$/.test(t)) {
+    // "930" → 09:30, "1740" → 17:40
+    const padded = t.padStart(4, '0')
+    h = parseInt(padded.slice(0, 2), 10)
+    m = parseInt(padded.slice(2), 10)
+  } else if (/^\d{1,2}$/.test(t)) {
+    h = parseInt(t, 10)
+    m = 0
+  } else {
+    return null
+  }
+
+  if (!isFinite(h) || !isFinite(m) || h < 0 || h > 23 || m < 0 || m > 59) return null
+  return h * 60 + m
+}


### PR DESCRIPTION
### What & why
Registering worked hours and absence currently means opening each employee's calendar one at a time. For a run with several people that's slow. This adds a table view at /salary/runs/[id]/time-entry where you enter and edit time for everyone in the run from one grid — and it pre-loads the time already saved for the period so existing entries can be edited or deleted in place, not just added.

### Changes

- New table view app/(dashboard)/salary/runs/[id]/time-entry/page.tsx + components/salary/BulkTimeEntryTable.tsx.
- Each row: searchable employee picker (filter by name or personnummer), type (Arbetad tid for hourly employees + absence types for everyone), date, hours, notes, per-row status.
- Pre-loads every saved worked-day and absence-day for the period; editing the employee/date/type rewrites the underlying record (deletes the old key first), while hours/notes overwrite in place. Trash deletes the saved record.
- Hours accept a plain number or a clock range (1740-2240), with overnight wrap (1740-0030 → 6.83) and Swedish decimal comma. Parsing extracted to lib/salary/parse-hours.ts with unit tests.
- Saves run sequentially against the existing worked-hours/absence endpoints so the 24h/day cap surfaces per row; only new or changed rows are written.
- Run detail page: a "Registrera tid" link into the view, and the Beräkningsdetaljer card is now collapsible.


### Checks

- `npm run lint`clean for changed files; `npm test` 4650 passing;

### Notes

- No DB/API changes — reuses the existing worked-hours and absence routes.
- Worked time is only offered for hourly employees; absence applies to all.
- Recalculate the run after editing for the amounts to update.