### PR TITLE
fix: removed incorrect `.si` file extension from supported formats

### DIFF
--- a/app/(dashboard)/import/page.tsx
+++ b/app/(dashboard)/import/page.tsx
@@ -2107,7 +2107,7 @@ export default function ImportPage() {
                   {t('sie_description')}
                 </p>
                 <div className="flex flex-wrap gap-1.5 mt-2.5">
-                  {['SIE4', '.se', '.si'].map(fmt => (
+                  {['SIE4', '.se'].map(fmt => (
                     <span key={fmt} className="text-[11px] text-muted-foreground/80 bg-muted/80 px-1.5 py-0.5 rounded leading-none">
                       {fmt}
                     </span>


### PR DESCRIPTION
Description
<img width="563" height="120" alt="screenshot-2026-06-03_11-40-58" src="https://github.com/user-attachments/assets/cb9e3b91-e8e2-4933-9bc0-deba64852475" />

(forcing an upload of `.si` produces this error message)
<img width="417" height="155" alt="screenshot-2026-06-03_11-41-39" src="https://github.com/user-attachments/assets/5c75894e-9c0f-485c-be5a-fb2869c11bb2" />

