### PR TITLE
docs: add .env.example for non-Docker local development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,27 @@
+# Local development environment variables.
+# Copy to .env and fill in the values: cp .env.example .env
+
+# ── Required ──────────────────────────────────────────────
+# Supabase project credentials (Dashboard -> Settings -> API)
+NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-or-publishable-key
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-or-secret-key
+
+# App base URL (local dev)
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# Secret for authenticating cron/scheduled requests.
+# Any non-empty random string for local dev: openssl rand -hex 16
+CRON_SECRET=generate-a-random-secret
+
+# ── Optional: extension features (core runs without these) ─
+# AI features
+# ANTHROPIC_API_KEY=
+# OPENAI_API_KEY=
+# Bank connections (Enable Banking)
+# ENABLE_BANKING_APP_ID=
+# ENABLE_BANKING_PRIVATE_KEY=
+# Accounting integrations
+# FORTNOX_CLIENT_ID=
+# FORTNOX_CLIENT_SECRET=
+# FORTNOX_REDIRECT_URI=

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel


### PR DESCRIPTION
## What
Adds `.env.example` for non-Docker local development, and un-ignores it in
`.gitignore` (`!.env.example`) so it's tracked while real `.env*` files stay
ignored.

## Why
CONTRIBUTING.md instructs contributors to run `cp .env.example .env`, but the
file didn't exist. The five required vars match `REQUIRED_CORE_VARS` in
`lib/init.ts` (Supabase URL / anon / service-role, `NEXT_PUBLIC_APP_URL`,
`CRON_SECRET`). Optional extension vars are included as comments.

## Open question
#597 adds `.env.docker.example` for the Docker/self-hosting path. This adds a
separate `.env.example` for the non-Docker dev flow CONTRIBUTING describes. If
you'd prefer to consolidate to a single template, happy to adapt or close —
just let me know.

## Notes
- Refs #564.
- No core, extension, or migration code touched.
- File ends with a trailing newline.