### PR TITLE
fix: update Claude.ai MCP connector instructions to current UI

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1449,7 +1449,7 @@
     "copy_aria": "Copy",
     "connect_mcp_title": "Connect MCP client",
     "recommended_badge": "Recommended",
-    "claude_ai_instructions": "Go to <path>Settings → Integrations → Add Integration</path> and paste the MCP server URL. You sign in via your {connectorName} account — no API key needed.",
+    "claude_ai_instructions": "Go to <path>Settings → Connectors → Add custom connector</path> and paste the MCP server URL. You sign in via your {connectorName} account — no API key needed.",
     "claude_code_cursor": "Claude Code / Cursor",
     "terminal_runs_browser_login": "Run in the terminal — sign in via the browser:",
     "connect_with_api_key": "Connect with an API key instead",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -1449,7 +1449,7 @@
     "copy_aria": "Kopiera",
     "connect_mcp_title": "Anslut MCP-klient",
     "recommended_badge": "Rekommenderat",
-    "claude_ai_instructions": "Gå till <path>Settings → Integrations → Add Integration</path> och klistra in MCP-serverns URL. Du loggas in via ditt {connectorName}-konto — ingen API-nyckel behövs.",
+    "claude_ai_instructions": "Gå till <path>Settings → Connectors → Add custom connector</path> och klistra in MCP-serverns URL. Du loggas in via ditt {connectorName}-konto — ingen API-nyckel behövs.",
     "claude_code_cursor": "Claude Code / Cursor",
     "terminal_runs_browser_login": "Kör i terminalen — loggar in via webbläsaren:",
     "connect_with_api_key": "Anslut med API-nyckel istället",


### PR DESCRIPTION
## What
Updates the Claude.ai MCP connection instructions (en and sv locales) from
the old "Settings → Integrations → Add Integration" path to the current
"Settings → Connectors → Add custom connector".

## Why
Anthropic renamed this flow from "Integrations" to "Connectors", so the
existing instructions no longer match Claude's UI. Kept the path literal
and concise rather than hedging across plan/client variations, to stay
easy for users to follow.

## Notes
- Only the two locale strings changed; {connectorName} placeholder and
  <path> markup preserved.
- en and sv were the only locales containing the old string.
- No code, extension, or migration changes.