### PR TITLE
fix(inbox): fall back to supplier.default_expense_account in create_supplier_invoice_from_inbox

### DIFF
--- a/extensions/general/mcp-server/server.ts
+++ b/extensions/general/mcp-server/server.ts
@@ -6234,6 +6234,16 @@ export const tools: McpTool[] = [
         )
       }
 
+      // Fetch supplier defaults so line items can inherit default_expense_account
+      // when neither the extraction nor the agent provided an accountSuggestion.
+      const { data: resolvedSupplier } = await supabase
+        .from('suppliers')
+        .select('default_expense_account')
+        .eq('id', supplierId)
+        .eq('company_id', companyId)
+        .single()
+      const supplierDefaultExpenseAccount = resolvedSupplier?.default_expense_account ?? null
+
       // Assemble core invoice fields
       const currency = (invoiceExt?.currency as string) || 'SEK'
       const invoiceDate = (invoiceExt?.invoiceDate as string) || null
@@ -6263,7 +6273,7 @@ export const tools: McpTool[] = [
       }
 
       // Translate extracted line items into the supplier_invoice_items shape.
-      // Default account 4000 (varuinköp/inköp) when extraction didn't pin one.
+      // Priority: per-line accountSuggestion → supplier.default_expense_account → 4000.
       const lineItems = lineItemsExt.map((li, idx) => ({
         line_number: idx + 1,
         description: (li.description as string) ?? `Position ${idx + 1}`,
@@ -6271,7 +6281,7 @@ export const tools: McpTool[] = [
         unit: (li.unit as string) ?? 'st',
         unit_price: Number(li.unit_price ?? li.unitPrice ?? li.amount) || 0,
         line_total: Number(li.line_total ?? li.lineTotal ?? li.amount) || 0,
-        account_number: (li.account_number as string | undefined) ?? '4000',
+        account_number: (li.accountSuggestion as string | null) ?? supplierDefaultExpenseAccount ?? '4000',
         vat_rate: Number(li.vat_rate ?? li.vatRate) || 0,
         vat_amount: Number(li.vat_amount ?? li.vatAmount) || 0,
       }))


### PR DESCRIPTION
## Summary

- The line-item account lookup used `li.account_number` (snake_case) which is never populated in the extraction schema — the actual field is `li.accountSuggestion` (camelCase). So the per-line account was silently ignored every time.
- After resolving the supplier, the tool now fetches `default_expense_account` and uses it as the fallback when `accountSuggestion` is null, before falling through to the hardcoded `4000`.

**Priority chain:** `lineItem.accountSuggestion` → `supplier.default_expense_account` → `'4000'`

## Test plan

- [ ] Supplier with `default_expense_account = '5410'`, inbox item with no `accountSuggestion` on lines → all lines get `5410`
- [ ] Supplier with `default_expense_account = '5410'`, line with `accountSuggestion = '6212'` → that line gets `6212`, others get `5410`
- [ ] Supplier with `default_expense_account = null` → falls through to `4000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)