### PR TITLE
fix(inbox): set_inbox_extracted_data should accept and persist accountSuggestion

### DIFF
--- a/extensions/general/invoice-inbox/lib/extract-invoice-fields.ts
+++ b/extensions/general/invoice-inbox/lib/extract-invoice-fields.ts
@@ -110,6 +110,22 @@ export const ExtractionSchema = z.object({
   ),
 })
 
+// Agent-supplied extraction: accountSuggestion is preserved instead of forced
+// to null. Agents (unlike AI extractors) can reliably assign a BAS expense
+// account; the regex enforces the class-4–7 range required for cost accounts.
+export const AgentExtractionSchema = ExtractionSchema.omit({ lineItems: true }).extend({
+  lineItems: z.array(
+    z.object({
+      description: z.string(),
+      quantity: z.number(),
+      unitPrice: z.number().nullable(),
+      lineTotal: z.number(),
+      vatRate: z.number().min(0).max(100).nullable(),
+      accountSuggestion: z.string().regex(/^[4-7]\d{3}$/).nullable(),
+    })
+  ),
+})
+
 const SYSTEM_PROMPT = `You extract invoice and receipt fields from a single document for a Swedish accounting system.
 
 Return ONLY a single JSON object that matches this schema exactly. No prose, no markdown fences, no commentary.

--- a/extensions/general/mcp-server/server.ts
+++ b/extensions/general/mcp-server/server.ts
@@ -74,7 +74,7 @@ import {
   generateInvoiceEmailSubject,
 } from '@/lib/email/invoice-templates'
 import { uploadDocument, MAX_DOCUMENT_SIZE } from '@/lib/core/documents/document-service'
-import { extractInvoiceFields, ExtractionSchema as InvoiceExtractionSchema } from '@/extensions/general/invoice-inbox/lib/extract-invoice-fields'
+import { extractInvoiceFields, ExtractionSchema as InvoiceExtractionSchema, AgentExtractionSchema } from '@/extensions/general/invoice-inbox/lib/extract-invoice-fields'
 // Skatteverket filing tools (PR5). Cross-extension lib import, same sanctioned
 // pattern as invoice-inbox above — the CI guard only checks lib/, app/api/,
 // components/. The two submit tools stage ops whose commit dispatches back into
@@ -9580,7 +9580,7 @@ export const tools: McpTool[] = [
         inbox_item_id: { type: 'string', description: 'UUID of the invoice_inbox_items row' },
         extracted_data: {
           type: 'object',
-          description: 'Full InvoiceExtractionResult (supplier, invoice, lineItems, totals, vatBreakdown). Validated server-side via the same Zod schema as the AI extractor.',
+          description: 'Full InvoiceExtractionResult (supplier, invoice, lineItems, totals, vatBreakdown). lineItems.accountSuggestion accepts a BAS expense account (4xxx–7xxx); AI extractor always emits null here.',
         },
       },
       required: ['inbox_item_id', 'extracted_data'],
@@ -9600,10 +9600,12 @@ export const tools: McpTool[] = [
       const inboxItemId = args.inbox_item_id as string
       if (!inboxItemId) throw new Error('inbox_item_id is required')
 
-      const parsed = InvoiceExtractionSchema.parse(args.extracted_data)
+      const parsed = AgentExtractionSchema.parse(args.extracted_data)
       // BYO extraction: confidence 0.95 marks the result as agent-supplied
       // (vs 1.0 the AI extractor uses on a perfect parse) so downstream UI
       // can render the provenance differently (ISO 27001 A.8.12).
+      // AgentExtractionSchema (unlike InvoiceExtractionSchema) preserves
+      // accountSuggestion so agents can pin a BAS cost account per line.
       const extracted = { ...parsed, confidence: 0.95 }
 
       const { data: item, error: fetchError } = await supabase


### PR DESCRIPTION
## Summary

- `set_inbox_extracted_data` was using `InvoiceExtractionSchema`, which forcibly transforms every `lineItems[].accountSuggestion` to `null`. That guard exists to prevent the AI extractor from hallucinating BAS accounts — but it also silently dropped any account an agent explicitly supplied.
- Adds `AgentExtractionSchema` (exported from `extract-invoice-fields.ts`) where `accountSuggestion` accepts a validated BAS expense account (`/^[4-7]\d{3}$/`) or `null`. The AI extraction path is unchanged.
- `set_inbox_extracted_data` now parses through `AgentExtractionSchema` so the field survives to the DB and flows into `gnubok_create_supplier_invoice_from_inbox` (see companion PR #759 which picks it up there).

## Test plan

- [ ] Call `set_inbox_extracted_data` with a line item `accountSuggestion: "5410"` → persisted in `extracted_data`, readable via `get_inbox_item`
- [ ] Call with `accountSuggestion: "9999"` (invalid class) → Zod validation error returned, not persisted
- [ ] AI extraction path still produces `accountSuggestion: null` on every line (existing test `forces accountSuggestion to null` still passes)
- [ ] Follow with `create_supplier_invoice_from_inbox` → line uses `5410`, not the supplier default or `4000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)