### PR TITLE
fix(transactions): include 'overdue' in match-supplier-invoice CAS guard

### DIFF
--- a/app/api/transactions/[id]/match-supplier-invoice/__tests__/route.test.ts
+++ b/app/api/transactions/[id]/match-supplier-invoice/__tests__/route.test.ts
@@ -81,6 +81,7 @@ function enqueueHappyPath(opts: {
     exchange_rate?: number | null
     remaining_amount?: number
     paid_amount?: number
+    status?: string
   }
   accountingMethod?: string
 }) {
@@ -103,7 +104,7 @@ function enqueueHappyPath(opts: {
       id: SI_UUID,
       currency: opts.invoice.currency,
       exchange_rate: opts.invoice.exchange_rate ?? null,
-      status: 'registered',
+      status: opts.invoice.status ?? 'registered',
       remaining_amount: opts.invoice.remaining_amount ?? 225,
       paid_amount: opts.invoice.paid_amount ?? 0,
       supplier: { supplier_type: 'eu_business' },
@@ -283,6 +284,18 @@ describe('POST /api/transactions/[id]/match-supplier-invoice — non-FX paths', 
     expect(details.transaction_amount).toBe(6000)
     expect(details.remaining_amount).toBe(5000)
     expect(details.excess).toBe(1000)
+  })
+
+  it('succeeds for an overdue invoice (status is a valid CAS target)', async () => {
+    // Regression: CAS guard previously omitted 'overdue', so selecting an overdue
+    // invoice from SupplierInvoicePicker would commit a JE, fail the update, orphan
+    // the voucher, and return MATCH_SI_NOT_OPEN.
+    enqueueHappyPath({
+      transaction: { amount: -1000, currency: 'SEK' },
+      invoice: { currency: 'SEK', remaining_amount: 1000, status: 'overdue' },
+    })
+    const res = await POST(makeReq(), createMockRouteParams({ id: TX_UUID }))
+    expect(res.status).toBe(200)
   })
 
   it('does NOT trigger overshoot guard on currency mismatch (FX path clamps to remaining)', async () => {

--- a/app/api/transactions/[id]/match-supplier-invoice/route.ts
+++ b/app/api/transactions/[id]/match-supplier-invoice/route.ts
@@ -330,7 +330,7 @@ export const POST = withRouteContext(
         transaction_id: transactionId,
       })
       .eq('id', supplier_invoice_id)
-      .in('status', ['registered', 'approved', 'partially_paid'])
+      .in('status', ['registered', 'approved', 'partially_paid', 'overdue'])
       .select('id')
 
     if (updateInvError) {


### PR DESCRIPTION
## Summary

- `SupplierInvoicePicker` shows supplier invoices with status `'overdue'` as payable candidates
- The CAS update in `POST /api/transactions/[id]/match-supplier-invoice` only whitelisted `['registered', 'approved', 'partially_paid']`, omitting `'overdue'`
- For any overdue invoice: the early `'paid'|'credited'` guard passes, a journal entry is committed, the CAS returns 0 rows, the voucher is orphaned, and `MATCH_SI_NOT_OPEN` is returned ("Leverantörsfakturan har slutbetalats av en annan förfrågan")
- The v1 route already had `'overdue'` in its CAS guard — this syncs the original route to match

The bug surfaced most visibly after using the split-payment dialog (`MatchAllocationDialog`), which calls `match-batch` (the RPC handles `'overdue'` correctly). After splitting to pay approved invoices, the remaining open invoices tended to be overdue, and every subsequent single-match attempt would fail.

## Test plan

- [x] Regression test: overdue invoice match returns 200
- [x] Extended `enqueueHappyPath` helper to accept an optional `invoice.status`
- [x] All 18 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)