### PR TITLE
fix(arcim-migration): dedup customers/suppliers by name when org-number is absent

### DIFF
--- a/extensions/general/arcim-migration/lib/migration-orchestrator.ts
+++ b/extensions/general/arcim-migration/lib/migration-orchestrator.ts
@@ -176,9 +176,18 @@ export async function executeMigration(options: MigrationOptions): Promise<Migra
             continue
           }
 
+          // Dedup against already-imported records: prefer org-number, but fall
+          // back to name when the party has no org-number. Otherwise org-less
+          // customers (private persons) are re-created on every re-sync, since
+          // the org-number map can never match them.
           const orgNumber = getOrgNumberFromParty(customer.party)
-          if (orgNumber && orgNumberToCustomerId.has(orgNumber)) {
-            customerIdMap.set(customer.id, orgNumberToCustomerId.get(orgNumber)!)
+          const existingCustomerId = orgNumber
+            ? orgNumberToCustomerId.get(orgNumber)
+            : customer.party.name
+              ? nameToCustomerId.get(customer.party.name)
+              : undefined
+          if (existingCustomerId) {
+            customerIdMap.set(customer.id, existingCustomerId)
             skipReasons.duplicate = (skipReasons.duplicate ?? 0) + 1
             skipped++
             continue
@@ -257,9 +266,16 @@ export async function executeMigration(options: MigrationOptions): Promise<Migra
             continue
           }
 
+          // Same org-number-then-name dedup as customers, so org-less suppliers
+          // (e.g. PostNord, IKANO BANK) aren't duplicated on every re-sync.
           const orgNumber = getOrgNumberFromParty(supplier.party)
-          if (orgNumber && orgNumberToSupplierId.has(orgNumber)) {
-            supplierIdMap.set(supplier.id, orgNumberToSupplierId.get(orgNumber)!)
+          const existingSupplierId = orgNumber
+            ? orgNumberToSupplierId.get(orgNumber)
+            : supplier.party.name
+              ? nameToSupplierId.get(supplier.party.name)
+              : undefined
+          if (existingSupplierId) {
+            supplierIdMap.set(supplier.id, existingSupplierId)
             skipReasons.duplicate = (skipReasons.duplicate ?? 0) + 1
             skipped++
             continue


### PR DESCRIPTION
Fixes #787.

## Problem

The system-migration (`arcim-migration`) register import skips already-imported **customers** and **suppliers** by **org-number only**:

```ts
const orgNumber = getOrgNumberFromParty(customer.party)
if (orgNumber && orgNumberToCustomerId.has(orgNumber)) { /* skip as duplicate */ }
```

Records **without** an org-number — private-person customers, suppliers like PostNord / IKANO BANK / PostNord — can never match this check, so **every re-sync re-creates them**, and re-creates their invoices too (the supplier-invoice dedup keys on `supplier_id`, which is freshly minted each run). The result is 2×, 3×, 4× duplicate suppliers/customers and duplicate invoices after repeated syncs.

Observed live: after 4 syncs, 7 org-less suppliers existed 4× each (68 supplier rows vs 47 real) with their invoices quadrupled; on the next sync a private customer with no org-number duplicated the same way.

## Fix

The `nameToCustomerId` / `nameToSupplierId` maps are **already built and populated** in this function — they just weren't consulted for dedup. Use them as a fallback: match on org-number when present, otherwise on name.

```ts
const existingCustomerId = orgNumber
  ? orgNumberToCustomerId.get(orgNumber)
  : customer.party.name ? nameToCustomerId.get(customer.party.name) : undefined
if (existingCustomerId) { /* skip as duplicate */ }
```

This mirrors the sales-invoice customer-stub path in the same file, which already keys on `org ?? name`. When an org-number **is** present we still match on it alone, so two distinct legal entities that happen to share a name aren't wrongly merged.

## Scope

20-line change to `migration-orchestrator.ts`, customers + suppliers steps. No schema or API changes. Idempotent re-syncs become safe.