### PR TITLE
fix(ci): switch compliance review to pull_request_target so fork PRs can post comments

### DIFF
--- a/.github/workflows/swedish-compliance-review.yml
+++ b/.github/workflows/swedish-compliance-review.yml
@@ -1,7 +1,7 @@
 name: Swedish Accounting Compliance Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 permissions:
@@ -14,6 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary

- `on: pull_request` gives fork PRs a read-only `GITHUB_TOKEN` even when `pull-requests: write` is declared — this is a GitHub security restriction added in 2021
- Switching to `pull_request_target` runs the job in the base-repo context so the token has write access to post/update the review comment
- Added `ref: ${{ github.event.pull_request.head.sha }}` on the checkout step so the PR's actual code is reviewed, not the base branch

## Test plan

- [ ] Open or sync a fork PR and confirm the compliance review job posts its comment successfully
- [ ] Confirm the diff reviewed is from the PR branch, not main

🤖 Generated with [Claude Code](https://claude.com/claude-code)