### PR TITLE
fix: quote workflow name with embedded colon in compliance-swarm.yml

### DIFF
--- a/.github/workflows/compliance-swarm.yml
+++ b/.github/workflows/compliance-swarm.yml
@@ -1,4 +1,4 @@
-name: compliance: full swarm
+name: "compliance: full swarm"
 
 # Full hybrid audit: deterministic scanners + LLM-driven deep_audit checks
 # (RoPA drift, AGPL §13 evaluation, IDOR/access-control reasoning, ISMS clause


### PR DESCRIPTION
## Summary
- Fixes the "Invalid workflow file" check failure on `.github/workflows/compliance-swarm.yml` line 1.
- The unquoted `name: compliance: full swarm` value contains a colon+space, which YAML parses as the start of a nested mapping, so GitHub Actions rejected the whole file.
- Quoted the value: `name: "compliance: full swarm"`.

## Test plan
- [x] Verified the file parses cleanly with `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/compliance-swarm.yml'))"`
- [x] Confirmed the `name` field still evaluates to the intended string `compliance: full swarm`