### PR TITLE
fix(transactions): stop hardcoding bank line description to the 1930 label

### DIFF
--- a/components/transactions/TransactionBookingDialog.tsx
+++ b/components/transactions/TransactionBookingDialog.tsx
@@ -117,10 +117,12 @@ export default function TransactionBookingDialog({
   const [pickedInboxDocs, setPickedInboxDocs] = useState<AvailableInboxDoc[]>([])
   const [inboxPickerOpen, setInboxPickerOpen] = useState(false)
   const [bankAccount, setBankAccount] = useState<string | null>(null)
+  const [bankAccountName, setBankAccountName] = useState<string | null>(null)
 
   useEffect(() => {
     if (!open || !transaction) return
     setBankAccount(null)
+    setBankAccountName(null)
     let cancelled = false
     fetch('/api/cash-accounts')
       .then((r) => {
@@ -135,7 +137,12 @@ export default function TransactionBookingDialog({
           transaction.cash_account_id ?? null,
           transaction.currency ?? 'SEK',
         )
+        // Use the matched account's own name instead of a generic label.
+        const matched =
+          accounts.find((a) => a.id === transaction.cash_account_id) ??
+          accounts.find((a) => a.ledger_account === account)
         setBankAccount(account)
+        setBankAccountName(matched?.name ?? null)
       })
       .catch(() => {
         if (!cancelled) setBankAccount('1930')
@@ -362,7 +369,7 @@ export default function TransactionBookingDialog({
                 initialLines={
                   preselectedTemplate
                     ? buildInitialLinesFromTemplate(transaction, preselectedTemplate, bankAccount)
-                    : buildInitialLines(transaction, t('bank_line_description'), bankAccount)
+                    : buildInitialLines(transaction, bankAccountName ?? t('bank_line_description'), bankAccount)
                 }
                 initialDate={transaction.date}
                 initialDescription={transaction.description}


### PR DESCRIPTION
## Summary

Follow-up to #769. That PR fixed the booking dialog to resolve the actual bank account from `cash_account_id` instead of hardcoding `1930`, but the journal line's `line_description` was still always the generic `bank_line_description` translation ("Företagskonto" / "Business account"), which only happened to be correct when every transaction hit the same default account.

- `TransactionBookingDialog` now looks up the resolved cash account's own `name` (via the same `/api/cash-accounts` fetch already used to resolve the ledger account) and uses it as the bank line's description, falling back to the generic translation when the account has no name.

## Test plan

- [x] `npx tsc --noEmit` clean on the changed file
- [x] `npx eslint components/transactions/TransactionBookingDialog.tsx` — only a pre-existing `react-hooks/exhaustive-deps` warning, unchanged by this diff
- [ ] Manually book a bank transaction against a non-default cash account (e.g. a secondary or foreign-currency account) and confirm the line description matches that account's name

🤖 Generated with [Claude Code](https://claude.com/claude-code)