### PR TITLE
fix(ci): quote compliance-pr.yml name to fix invalid YAML

### DIFF
--- a/.github/workflows/compliance-pr.yml
+++ b/.github/workflows/compliance-pr.yml
@@ -1,4 +1,4 @@
-name: compliance: review (advisory)
+name: "compliance: review (advisory)"
 
 # Lightweight LLM-only review on every PR. ~90s, no Docker scanners.
 # Posts a sticky comment with reasoned findings across all 5 frameworks.


### PR DESCRIPTION
## Summary
- `#890` swapped the em dash in `.github/workflows/compliance-pr.yml`'s `name:` for an unquoted colon, which YAML parses as a nested mapping key ("mapping values are not allowed here", line 1). GitHub can't parse the workflow at all as a result, so every run of it — push or pull_request, on any branch across the whole repo — fails immediately with 0 jobs scheduled.
- Quotes the name string so it parses again, without reintroducing an em/en dash.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/compliance-pr.yml'))"` parses cleanly
- [ ] Confirm a subsequent PR run of `compliance-pr.yml` actually schedules a job

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the compliance workflow’s display name for improved configuration compatibility.
  * No changes to workflow triggers, permissions, jobs, or execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->