### PR TITLE
Fix crash clicking a "Tidigare motparter" suggestion

### DIFF
--- a/app/(dashboard)/transactions/page.tsx
+++ b/app/(dashboard)/transactions/page.tsx
@@ -2163,7 +2163,12 @@ export default function TransactionsPage() {
         transaction,
         category: transaction.amount < 0 ? 'expense_other' : 'income_services',
         label: cpSuggestion.name_sv,
-        template: { id: templateId, name_sv: cpSuggestion.name_sv } as BookingTemplate,
+        template: {
+          id: templateId,
+          name_sv: cpSuggestion.name_sv,
+          debit_account: cpSuggestion.debit_account,
+          credit_account: cpSuggestion.credit_account,
+        } as BookingTemplate,
         templateId: undefined,
         linePattern: cpSuggestion.line_pattern ?? null,
         defaultDimensions: cpSuggestion.default_dimensions ?? null,

--- a/components/transactions/QuickReviewDialog.tsx
+++ b/components/transactions/QuickReviewDialog.tsx
@@ -202,7 +202,7 @@ export default function QuickReviewDialog({
   const isIncome = tx.amount > 0
   const isCounterpartyTemplate = !!(counterpartyLinePattern && counterpartyLinePattern.length > 0)
   const isTemplateBooking = !!templateId || isCounterpartyTemplate
-  const isLiabilityAccount = accountOverride.startsWith('2')
+  const isLiabilityAccount = !!accountOverride?.startsWith('2')
   // For non-SEK transactions, the verifikation and the headline must show
   // the SEK-converted total: the mall/category booking always posts in SEK.
   const sekAmount = resolveSekAmount(


### PR DESCRIPTION
## Summary
- Clicking a "Tidigare motparter" (previous counterparty) suggestion in the Bokför transaktion dialog navigated to the generic error page ("Något gick fel").
- Root cause: `handleOpenTemplateReview` (app/(dashboard)/transactions/page.tsx) built a fake `BookingTemplate` for the counterparty path with only `id`/`name_sv`, cast with `as BookingTemplate` to bypass the type checker. This left `debit_account`/`credit_account` undefined, so `QuickReviewDialog`'s `defaultAccount` prop resolved to `undefined`, and the unconditional `accountOverride.startsWith('2')` check threw a `TypeError` during render — caught by the dashboard error boundary.
- Fix: populate the fake template with `debit_account`/`credit_account` already returned by the suggest-categories API, and guard the `startsWith` call defensively.

## Test plan
- [x] `npm run check:lint`
- [x] `npm run check:guards`
- [x] `npx vitest run --project unit lib/bookkeeping/__tests__/counterparty-templates.test.ts components/transactions/__tests__` (155 passed)
- [x] `npx tsc --noEmit` clean on touched files
- [ ] Manual click-through on a transaction with previous counterparty suggestions (not run in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction template reviews by preserving selected debit and credit account details.
  * Prevented errors when an account override is not selected during quick review.
  * Maintained correct liability and equity account handling when account information is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->