### PR TITLE
fix: expose inbox filenames via MCP

### DIFF
--- a/extensions/general/mcp-server/__tests__/list-inbox-items.test.ts
+++ b/extensions/general/mcp-server/__tests__/list-inbox-items.test.ts
@@ -41,7 +41,7 @@ describe('gnubok_list_inbox_items', () => {
           email_from: null,
           email_subject: null,
           error_message: null,
-          document_attachments: { file_name: 'dooer-export-2026-07.pdf' },
+          document_attachments: [{ file_name: 'dooer-export-2026-07.pdf' }],
         },
         {
           id: 'inbox-2',
@@ -56,7 +56,7 @@ describe('gnubok_list_inbox_items', () => {
           email_from: null,
           email_subject: null,
           error_message: null,
-          document_attachments: null,
+          document_attachments: [],
         },
       ],
       error: null,

--- a/extensions/general/mcp-server/__tests__/list-inbox-items.test.ts
+++ b/extensions/general/mcp-server/__tests__/list-inbox-items.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import { createQueuedMockSupabase } from '@/tests/helpers'
+import { tools } from '../server'
+
+const tool = tools.find((candidate) => candidate.name === 'gnubok_list_inbox_items')!
+
+describe('gnubok_list_inbox_items', () => {
+  it('advertises file_name in its item output contract', () => {
+    const schema = tool.outputSchema as {
+      properties: {
+        items: {
+          items: {
+            properties: Record<string, unknown>
+            required: string[]
+          }
+        }
+      }
+    }
+
+    expect(schema.properties.items.items.properties.file_name).toEqual({
+      type: ['string', 'null'],
+      description: 'Original document file name, or null when the inbox item has no document',
+    })
+    expect(schema.properties.items.items.required).toContain('file_name')
+  })
+
+  it('joins the document and returns its file_name on each list row', async () => {
+    const { supabase, enqueue, findCall } = createQueuedMockSupabase()
+    enqueue({
+      data: [
+        {
+          id: 'inbox-1',
+          status: 'received',
+          source: 'upload',
+          created_at: '2026-07-31T12:00:00Z',
+          extracted_data: null,
+          matched_supplier_id: null,
+          matched_transaction_id: null,
+          created_supplier_invoice_id: null,
+          created_journal_entry_id: null,
+          email_from: null,
+          email_subject: null,
+          error_message: null,
+          document_attachments: { file_name: 'dooer-export-2026-07.pdf' },
+        },
+        {
+          id: 'inbox-2',
+          status: 'received',
+          source: 'email',
+          created_at: '2026-07-30T12:00:00Z',
+          extracted_data: null,
+          matched_supplier_id: null,
+          matched_transaction_id: null,
+          created_supplier_invoice_id: null,
+          created_journal_entry_id: null,
+          email_from: null,
+          email_subject: null,
+          error_message: null,
+          document_attachments: null,
+        },
+      ],
+      error: null,
+    })
+
+    const result = (await tool.execute({}, 'company-1', 'user-1', supabase as never)) as {
+      items: Array<{ file_name: string | null }>
+      count: number
+    }
+
+    const select = findCall('invoice_inbox_items', 'select')?.[0]
+    expect(select).toContain('document_attachments(file_name)')
+    expect(result.items.map((item) => item.file_name)).toEqual([
+      'dooer-export-2026-07.pdf',
+      null,
+    ])
+    expect(result.count).toBe(2)
+  })
+})

--- a/extensions/general/mcp-server/server.ts
+++ b/extensions/general/mcp-server/server.ts
@@ -9159,7 +9159,7 @@ export const tools: McpTool[] = [
   {
     name: 'gnubok_list_inbox_items',
     title: 'List Inbox Items',
-    description: 'List document inbox items. `processed` covers all terminal links (transaction, supplier invoice, journal entry); booked receipts count as done. unprocessed_only=true returns docs still needing handling.',
+    description: 'List document inbox items, including each original file_name. `processed` covers all terminal links (transaction, supplier invoice, journal entry); booked receipts count as done. unprocessed_only=true returns docs still needing handling.',
     inputSchema: {
       type: 'object',
       additionalProperties: false,
@@ -9173,7 +9173,19 @@ export const tools: McpTool[] = [
       type: 'object',
       additionalProperties: false,
       properties: {
-        items: { type: 'array', items: { type: 'object' } },
+        items: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              file_name: {
+                type: ['string', 'null'],
+                description: 'Original document file name, or null when the inbox item has no document',
+              },
+            },
+            required: ['file_name'],
+          },
+        },
         count: { type: 'number' },
       },
       required: ['items', 'count'],
@@ -9191,7 +9203,11 @@ export const tools: McpTool[] = [
 
       let query = supabase
         .from('invoice_inbox_items')
-        .select('id, status, source, created_at, extracted_data, matched_supplier_id, matched_transaction_id, created_supplier_invoice_id, created_journal_entry_id, email_from, email_subject, error_message')
+        .select(`
+          id, status, source, created_at, extracted_data, matched_supplier_id,
+          matched_transaction_id, created_supplier_invoice_id, created_journal_entry_id,
+          email_from, email_subject, error_message, document_attachments(file_name)
+        `)
         .eq('company_id', companyId)
         .order('created_at', { ascending: false })
         // Fetch a wider window when filtering client-side so the limit
@@ -9234,6 +9250,7 @@ export const tools: McpTool[] = [
           status: item.status,
           source: item.source,
           created_at: item.created_at,
+          file_name: item.document_attachments?.file_name ?? null,
           vendor_name: vendorName,
           amount,
           invoice_date: invoiceDate,

--- a/extensions/general/mcp-server/server.ts
+++ b/extensions/general/mcp-server/server.ts
@@ -9250,7 +9250,7 @@ export const tools: McpTool[] = [
           status: item.status,
           source: item.source,
           created_at: item.created_at,
-          file_name: item.document_attachments?.file_name ?? null,
+          file_name: item.document_attachments?.[0]?.file_name ?? null,
           vendor_name: vendorName,
           amount,
           invoice_date: invoiceDate,


### PR DESCRIPTION
## Summary

- join each MCP inbox row to its existing document attachment
- return a flat nullable `file_name` from `gnubok_list_inbox_items`
- advertise the field in the MCP output schema and add regression coverage

## Why

`gnubok_list_inbox_items` omitted the attachment filename even though `gnubok_get_inbox_item` already exposed it. Agents matching exported Dooer documents to vouchers therefore needed one additional query per document.

## Impact

MCP clients can match inbox documents by their original filename directly from the list response. Items without an attachment return `file_name: null`.

## Validation

- `npx vitest run extensions/general/mcp-server/__tests__/list-inbox-items.test.ts extensions/general/mcp-server/__tests__/output-schema.test.ts extensions/general/mcp-server/__tests__/qualified-ids.test.ts extensions/general/mcp-server/__tests__/strict-schemas.test.ts` (12 passed)
- targeted ESLint on the changed server and test files (0 errors; existing server warnings only)
- full unit suite: 12,082 passed; four unrelated timeout failures passed when rerun alone, while the unchanged `scripts/checks/__tests__/format-currency-sek-label.test.ts` still has a baseline parse failure
