### PR TITLE
chore: union-merge DECISIONS.md to stop phantom-green conflicting PRs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,3 +18,11 @@ lib/bokslut/ixbrl/taxonomy/generated/*.json text eol=lf linguist-generated=true
 # the working tree matches what the generators write.
 lib/extensions/_generated/** text eol=lf linguist-generated=true
 *.snap text eol=lf linguist-generated=true
+
+# DECISIONS.md is an append-only log that every concurrent PR writes to, so
+# two PRs touching it always conflict at EOF. That is worse than it sounds:
+# GitHub runs ZERO Actions on a conflicting PR, so `gh pr checks` returns a
+# short all-pass list that looks green while nothing actually ran. A union
+# merge keeps both sides' lines (the file has no ordering contract beyond
+# the date prefix), which is exactly the right semantics for an append log.
+DECISIONS.md merge=union


### PR DESCRIPTION
Small infrastructure fix, independent of any feature work.

## Problem

Every concurrent PR appends a line to `DECISIONS.md`, so any two open PRs conflict at EOF. The conflict itself is trivial to resolve; the damage is second-order: **GitHub runs zero Actions on a conflicting PR**, so `gh pr checks` returns a short all-pass list that reads as green when the test suite never ran. That trap has already cost real debugging time on this repo (documented during the assistant-redesign batch, where the fix was "always verify the check COUNT, not just 0 pending").

Right now it is biting an 8-PR stack: `DECISIONS.md` is the ONLY file conflicting between the WhatsApp chain and current main.

## Fix

`DECISIONS.md merge=union` in `.gitattributes`. Union merge keeps both sides' lines, which is exactly right for an append-only log whose only ordering contract is the `[YYYY-MM-DD]` prefix. Git's `union` is a built-in merge driver, so no `.git/config` setup is required on any clone or in CI.

## Trade-off

Union merge never conflicts, so it also never asks a human about a genuinely contradictory pair of entries: two PRs can land decisions that disagree, and both lines survive. That is acceptable here because the log is chronological and additive by design (a later line superseding an earlier one is the normal pattern, and one recent entry does exactly that explicitly), and because the alternative is the silent-CI failure mode above. It does not apply to any other file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved merge handling for `DECISIONS.md` to help preserve changes when updates are combined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->