### PR TITLE
fix(build): break Turbopack chunk-name hash collision that blocks all production deploys

### DIFF
--- a/extensions/general/arcim-migration/lib/entity-mapper.ts
+++ b/extensions/general/arcim-migration/lib/entity-mapper.ts
@@ -8,7 +8,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { fetchExchangeRate } from '@/lib/currency/riksbanken'
 import { encryptCustomerPersonalNumber } from '@/lib/customers/protect-personal-number'
-import { normalizeVatRateToFraction } from '@/lib/vat/supplier-invoice-line-checks'
+import { normalizeVatRateToFraction } from '@/lib/vat/vat-rate-unit'
 import type { Currency, CustomerType, ExchangeRate, SupplierType, VatTreatment } from '@/types'
 import type {
   CustomerDto,

--- a/lib/vat/supplier-invoice-line-checks.ts
+++ b/lib/vat/supplier-invoice-line-checks.ts
@@ -2,6 +2,7 @@
 // Kept free of React so the rules can be unit-tested and reused.
 
 import { roundOre } from '@/lib/money'
+import { normalizeVatRateToFraction } from './vat-rate-unit'
 
 // Only 25/12/6/0 % are legal Swedish VAT rates (ML 2023:200). The supplier
 // invoice form stores rates as decimal fractions (0.25 = 25 %); this list is
@@ -17,20 +18,11 @@ export function isLegalVatRate(rate: number): boolean {
   return LEGAL_VAT_RATES.includes(rate)
 }
 
-/**
- * Convert a supplier-invoice VAT rate to the database's decimal-fraction
- * unit without changing the underlying rate. Values above 1 are interpreted
- * as percentages, while values already between 0 and 1 pass through. This is
- * intentionally a unit normalizer, not a Swedish-rate validator: imported
- * foreign VAT such as 19 % must remain 0.19 instead of being rewritten.
- */
-export function normalizeVatRateToFraction(rate: unknown): number {
-  const n = Number(rate)
-  if (!Number.isFinite(n) || n < 0) return 0
-
-  const fraction = n > 1 ? n / 100 : n
-  return fraction <= 1 ? fraction : 0
-}
+// normalizeVatRateToFraction lives in the import-free leaf module
+// vat-rate-unit.ts so extension entry graphs can use it without pulling in
+// this file's lib/money dependency; re-exported here so existing callers
+// keep their import path.
+export { normalizeVatRateToFraction }
 
 /**
  * Normalize a VAT rate that may arrive percent-shaped (25, 12, 6: the AI

--- a/lib/vat/vat-rate-unit.ts
+++ b/lib/vat/vat-rate-unit.ts
@@ -1,0 +1,21 @@
+// Leaf module on purpose: imported by extension entry graphs (arcim-migration
+// entity mapper) where pulling in supplier-invoice-line-checks' dependencies
+// (lib/money) shifted the server chunk graph into a Turbopack chunk-name hash
+// collision ("Two or more assets with different content were emitted to the
+// same output path", first seen on the #1385 merge). Keep this file free of
+// imports; supplier-invoice-line-checks re-exports it for all other callers.
+
+/**
+ * Convert a supplier-invoice VAT rate to the database's decimal-fraction
+ * unit without changing the underlying rate. Values above 1 are interpreted
+ * as percentages, while values already between 0 and 1 pass through. This is
+ * intentionally a unit normalizer, not a Swedish-rate validator: imported
+ * foreign VAT such as 19 % must remain 0.19 instead of being rewritten.
+ */
+export function normalizeVatRateToFraction(rate: unknown): number {
+  const n = Number(rate)
+  if (!Number.isFinite(n) || n < 0) return 0
+
+  const fraction = n > 1 ? n / 100 : n
+  return fraction <= 1 ? fraction : 0
+}


### PR DESCRIPTION
## Problem
Every production Vercel build of main has failed since the #1385 squash-merge (8443062b) with:

```
Turbopack build failed with 2 errors:
[output]/.next/server/chunks/[root-of-the-server]__1ge0sz5._.js
Two or more assets with different content were emitted to the same output path
```

Confirmed on three consecutive main builds (8443062b, 0ef3c039, ff864ad3); the live site is still serving the last good deploy (5b9605d8).

## Root cause
Two distinct server chunk groups (an AWS smithy helper chunk and the withRouteContext auth chunk; verified by diffing the two emitted assets) hash to the same [root-of-the-server] chunk name. The graph change that tipped the chunk layout into this colliding state was #1385 adding an import from the arcim-migration extension entry graph (entity-mapper.ts) to lib/vat/supplier-invoice-line-checks, which pulls lib/money into the extension root. Local bisect: 5b9605d8 builds clean, 8443062b fails.

## Fix
Behavior-identical import-graph change:
- new import-free leaf module lib/vat/vat-rate-unit.ts holds normalizeVatRateToFraction
- supplier-invoice-line-checks re-exports it, so every existing import path keeps working
- entity-mapper.ts imports the leaf module, restoring the extension root graph to the pre-#1385 shape that builds

## Verification
- npm run build: fails on ff864ad3 (reproduced locally), passes with this change
- npx vitest run lib/vat extensions/general/arcim-migration lib/pending-operations: 511/511 pass
- eslint clean on the three touched files

No runtime behavior change, no dependencies, no migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)