### PR TITLE
fix(bookkeeping): three static templates named accounts that break or mis-book

### DIFF
--- a/lib/bookkeeping/__tests__/booking-templates.test.ts
+++ b/lib/bookkeeping/__tests__/booking-templates.test.ts
@@ -426,7 +426,10 @@ describe('buildMappingResultFromTemplate', () => {
     const tx = makeTransaction({ amount: -1120 })
     const result = buildMappingResultFromTemplate(template, tx, 'enskild_firma')
 
-    expect(result.debit_account).toBe('5820')
+    // 5830 Kost och logi, not 5820 Hyrbilskostnader. This assertion used to
+    // read 5820, which pinned a real bug: the Hotell template posted hotel
+    // nights into car hire. It balanced, so nothing ever complained.
+    expect(result.debit_account).toBe('5830')
     expect(result.vat_lines).toHaveLength(1)
     expect(result.vat_lines[0].account_number).toBe('2641')
     expect(result.vat_lines[0].debit_amount).toBe(120) // 1120 * 0.12 / 1.12 = 120

--- a/lib/bookkeeping/__tests__/template-accounts-exist.test.ts
+++ b/lib/bookkeeping/__tests__/template-accounts-exist.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { BOOKING_TEMPLATES } from '@/lib/bookkeeping/booking-templates'
+import { getBASReference } from '@/lib/bookkeeping/bas-reference'
+
+/**
+ * Every account a booking template names must exist in BAS 2026.
+ *
+ * This is not pedantry: `lib/bookkeeping/account-backfill.ts` seeds a missing
+ * account into a company's chart on demand ONLY if it appears in
+ * BAS_REFERENCE. An account that does not is unreachable, so the template
+ * fails with AccountsNotInChartError every single time it is used, for every
+ * company. It is a template that can never work.
+ *
+ * Three shipped templates were in exactly that state until this test existed:
+ *   vehicle_parking    5614  (the BAS 561x run skips 5614)
+ *   it_cloud_hosting   5421  (BAS has 5420 Programvaror, no 5421)
+ *   preliminar-f-skatt-ef  2012  (found separately by the pack validator)
+ *
+ * The pack catalogue gets this check from `scripts/validate-packs.ts`. The
+ * static registry had nothing, which is why it drifted.
+ */
+describe('BOOKING_TEMPLATES reference only real BAS accounts', () => {
+  const accountFields = ['debit_account', 'credit_account', 'debit_account_ab', 'credit_account_ab'] as const
+
+  it('every referenced account resolves in BAS 2026', () => {
+    const missing: string[] = []
+
+    for (const t of BOOKING_TEMPLATES) {
+      for (const field of accountFields) {
+        const account = (t as unknown as Record<string, string | undefined>)[field]
+        if (!account) continue
+        if (!getBASReference(account)) {
+          missing.push(`${t.id}.${field} = ${account}`)
+        }
+      }
+    }
+
+    expect(
+      missing,
+      `These templates name accounts that do not exist in BAS 2026, so account-backfill ` +
+        `cannot seed them and every booking through them fails:\n  ${missing.join('\n  ')}`,
+    ).toEqual([])
+  })
+
+  it('account numbers are strings, never numbers', () => {
+    for (const t of BOOKING_TEMPLATES) {
+      for (const field of accountFields) {
+        const account = (t as unknown as Record<string, unknown>)[field]
+        if (account === undefined) continue
+        expect(typeof account, `${t.id}.${field}`).toBe('string')
+      }
+    }
+  })
+
+  it('a VAT-bearing purchase never debits equity or revenue', () => {
+    // Catches a transposed account number that happens to exist. Deliberately
+    // narrow: class 1 is legitimate here (equipment_capital debits 1250
+    // Inventarier and reclaims VAT, which is how capex is booked), and classes
+    // 4-7 are ordinary costs. What a purchase can never debit is class 2
+    // (equity and liabilities) or class 3 (revenue): those would be a sign
+    // error, not a categorisation choice.
+    const FORBIDDEN = new Set([2, 3])
+
+    for (const t of BOOKING_TEMPLATES) {
+      if (!t.vat_rate || t.direction !== 'expense') continue
+      const cls = Number(t.debit_account.charAt(0))
+      expect(
+        FORBIDDEN.has(cls),
+        `${t.id} charges VAT ${t.vat_rate} but debits ${t.debit_account} (class ${cls}): ` +
+          `a purchase cannot debit equity/liabilities or revenue`,
+      ).toBe(false)
+    }
+  })
+})

--- a/lib/bookkeeping/booking-templates.ts
+++ b/lib/bookkeeping/booking-templates.ts
@@ -268,7 +268,9 @@ export const BOOKING_TEMPLATES: readonly BookingTemplate[] = [
     group: 'vehicle',
     direction: 'expense',
     entity_applicability: 'all',
-    debit_account: '5614',
+    debit_account: '5619',  // 5614 does not exist in BAS 2026 (the 561x run skips it), so every
+    // booking through this template failed with AccountsNotInChartError.
+    // 5619 is the sibling 'Övriga kostnader för personbilar och mc'.
     credit_account: '1930',
     vat_treatment: 'standard_25',
     vat_rate: 0.25,
@@ -341,7 +343,8 @@ export const BOOKING_TEMPLATES: readonly BookingTemplate[] = [
     group: 'it_software',
     direction: 'expense',
     entity_applicability: 'all',
-    debit_account: '5421',
+    debit_account: '5420',  // 5421 does not exist in BAS 2026. 5420 Programvaror is what the two
+    // sibling SaaS templates already use.
     credit_account: '1930',
     vat_treatment: 'reverse_charge',
     vat_rate: 0,
@@ -538,7 +541,9 @@ export const BOOKING_TEMPLATES: readonly BookingTemplate[] = [
     group: 'travel',
     direction: 'expense',
     entity_applicability: 'all',
-    debit_account: '5820',
+    debit_account: '5830',  // 5820 is Hyrbilskostnader (rental car). This template is Hotell, so it
+    // posted hotel nights into car hire: it balanced and was silently wrong.
+    // 5830 is 'Kost och logi'.
     credit_account: '1930',
     vat_treatment: 'reduced_12',
     vat_rate: 0.12,


### PR DESCRIPTION
You asked me to analyse across the program. I cross-checked **all 86 booking templates** (26 packs + 60 static) against BAS 2026 on four axes: account existence, label-vs-account contradiction, the `ratio` ↔ `vat_rate` coupling, and disagreement between the two template systems.

**The pack catalogue is clean.** The static registry had three defects, none visible to any existing check.

## Two templates that could never work

`lib/bookkeeping/account-backfill.ts` seeds a missing account into a company's chart **only if it appears in `BAS_REFERENCE`**. An account that doesn't is unreachable, so the template fails with `AccountsNotInChartError` every time, for every company.

| Template | Was | Now | Why |
|---|---|---|---|
| `vehicle_parking` | `5614` | `5619` | The BAS 561x run skips 5614 entirely. 5619 is the sibling *"Övriga kostnader för personbilar och mc"*. |
| `it_cloud_hosting` | `5421` | `5420` | BAS has no 5421. Both sibling SaaS templates already use `5420 Programvaror`. |

## One that silently mis-booked, which is worse

| Template | Was | Now |
|---|---|---|
| `travel_hotel` | `5820` **Hyrbilskostnader** | `5830` **Kost och logi** |

The *Hotell* template filed hotel nights under **car hire**. It balanced, the account existed, nothing warned. This is the #1321 shape again: the name says one thing, the booking does another.

An existing test asserted `5820`, so the bug was pinned as expected output. That assertion now reads `5830` and carries the reason, so nobody "fixes" it back.

## The guard

`template-accounts-exist.test.ts` makes the 5614 class unable to return:

- every account any static template names must resolve in BAS 2026
- account numbers must be strings
- a VAT-bearing purchase may not debit equity (class 2) or revenue (class 3)

That last check is deliberately narrow. My first version required a cost account (4-7) and immediately flagged `equipment_capital`, which debits `1250 Inventarier` and reclaims VAT — **correct**, that is how capex is booked. Class 1 is legitimate; only a sign error lands in 2 or 3.

Verified the guard fails on `5614` and passes on `5619`, rather than trusting it.

The pack catalogue already had this check via `scripts/validate-packs.ts`. The static registry had nothing, which is how it drifted.

## What the audit did NOT find

No label-vs-account contradictions remain in the packs (the representation one was #1396), the `ratio` ↔ `vat_rate` coupling holds everywhere, and no two templates disagree on the VAT rate for a shared debit account.

## Verification

- `npm test`: 12,350 passed, 2 skipped
- `npm run lint`: 0 errors
- `npm run check:guards`: passes
- `npm run validate:packs`: 26 valid, 0 quarantined

## Related concern I want to flag, not bury

In #1388 I **added account `2012`** to the BAS reference, on the strength of the `swedish-year-end-closing` skill using it twice. This audit showed **three** in-repo sources omit it: the lib reference, `dev_docs/BASKONTOPLAN.md`, and `seed_chart_of_accounts()`. Only the skill says it exists.

I acted on one source against three. The consequence is bounded (the account is only seeded when something references it, and only the EF preliminär-F-skatt template does), but it deserves a primary-source check against bas.se rather than my judgement. Details in the PR discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)