### PR TITLE
fix(bokslut): unblur the pre-submission warning list on the årsredovisning page

### DIFF
--- a/app/(dashboard)/bookkeeping/year-end/arsredovisning/page.tsx
+++ b/app/(dashboard)/bookkeeping/year-end/arsredovisning/page.tsx
@@ -1035,15 +1035,12 @@ export default function ArsredovisningPage() {
               </Button>
             </span>
           </div>
-          <div
-            inert={INLAMNING_COMING_SOON}
-            aria-hidden={INLAMNING_COMING_SOON}
-            className={
-              INLAMNING_COMING_SOON
-                ? 'pointer-events-none select-none blur-[3px] opacity-60 space-y-4'
-                : 'space-y-4'
-            }
-          >
+          {/* The warning list stays SHARP even while direct submission is
+              gated: the warnings describe problems in the user's own report
+              (unmapped accounts, resultat vs 2099, AGM dates) and apply to
+              the paper PDF just as much as to digital inlämning. Blurring
+              them alongside the coming-soon Bolagsverket parts made the
+              pre-submission checklist unreadable in the default config. */}
           {data.warnings.length > 0 && (
             <div className="space-y-1 border-t border-border/60 pt-3 text-xs">
               <p className="font-medium">Innan inlämning till Bolagsverket:</p>
@@ -1054,13 +1051,20 @@ export default function ArsredovisningPage() {
               </ul>
             </div>
           )}
-          <p className="text-xs text-muted-foreground">
+          <p
+            inert={INLAMNING_COMING_SOON}
+            aria-hidden={INLAMNING_COMING_SOON}
+            className={
+              INLAMNING_COMING_SOON
+                ? 'pointer-events-none select-none blur-[3px] opacity-60 text-xs text-muted-foreground'
+                : 'text-xs text-muted-foreground'
+            }
+          >
             <strong className="text-foreground">Digital inlämning är frivillig.</strong> Den görs som iXBRL genom en
             ansluten programvara. Accounteds direktinlämning förblir stängd tills avtal,
             certifikat och Bolagsverkets acceptanstest är klara. PDF-flödet ovan är den
             separata vägen för pappersinlämning.
           </p>
-          </div>
         </div>
       </section>
 

--- a/components/bookkeeping/year-end/PreflightStep.tsx
+++ b/components/bookkeeping/year-end/PreflightStep.tsx
@@ -123,32 +123,23 @@ export function PreflightStep({ report, isLoading, error, onContinue }: Prefligh
 /**
  * Renders a blocker with a contextual action link when we can derive one.
  * Falls back to plain text otherwise.
- *
- * validateYearEndReadiness emits SWEDISH strings (the wizard is a "stays
- * Swedish" surface); the English alternates are kept as fallback so a link
- * never regresses if an older message slips through. Mirrors the MCP
- * classifier in extensions/general/mcp-server/server.ts: keep both in sync
- * with the engine wording in lib/core/bookkeeping/year-end-service.ts.
  */
 function BlockerRow({ blocker, report }: { blocker: string; report: BokslutReadinessReport }) {
   let href: string | null = null
   let actionLabel: string | null = null
 
-  if (/draft journal entries|utkast måste bokföras/i.test(blocker) && report.draftCount > 0) {
+  if (/draft journal entries/i.test(blocker) && report.draftCount > 0) {
     href = '/bookkeeping?status=draft'
     actionLabel = 'Visa utkast'
-  } else if (/voucher gap|verifikationsnummerglapp/i.test(blocker)) {
+  } else if (/voucher gap/i.test(blocker)) {
     href = '/bookkeeping/voucher-gaps'
     actionLabel = 'Hantera nummerlucka'
-  } else if (/trial balance|råbalansen/i.test(blocker)) {
+  } else if (/trial balance/i.test(blocker)) {
     href = '/reports/trial-balance'
     actionLabel = 'Öppna balansrapport'
-  } else if (/continuity|IB\/UB-kontinuiteten/i.test(blocker)) {
+  } else if (/continuity/i.test(blocker)) {
     href = '/bookkeeping'
     actionLabel = 'Granska ingående balans'
-  } else if (/unbooked transaction|saknar bokföring/i.test(blocker)) {
-    href = '/transactions'
-    actionLabel = 'Visa transaktioner'
   }
 
   return (

--- a/components/bookkeeping/year-end/PreflightStep.tsx
+++ b/components/bookkeeping/year-end/PreflightStep.tsx
@@ -123,23 +123,32 @@ export function PreflightStep({ report, isLoading, error, onContinue }: Prefligh
 /**
  * Renders a blocker with a contextual action link when we can derive one.
  * Falls back to plain text otherwise.
+ *
+ * validateYearEndReadiness emits SWEDISH strings (the wizard is a "stays
+ * Swedish" surface); the English alternates are kept as fallback so a link
+ * never regresses if an older message slips through. Mirrors the MCP
+ * classifier in extensions/general/mcp-server/server.ts: keep both in sync
+ * with the engine wording in lib/core/bookkeeping/year-end-service.ts.
  */
 function BlockerRow({ blocker, report }: { blocker: string; report: BokslutReadinessReport }) {
   let href: string | null = null
   let actionLabel: string | null = null
 
-  if (/draft journal entries/i.test(blocker) && report.draftCount > 0) {
+  if (/draft journal entries|utkast måste bokföras/i.test(blocker) && report.draftCount > 0) {
     href = '/bookkeeping?status=draft'
     actionLabel = 'Visa utkast'
-  } else if (/voucher gap/i.test(blocker)) {
+  } else if (/voucher gap|verifikationsnummerglapp/i.test(blocker)) {
     href = '/bookkeeping/voucher-gaps'
     actionLabel = 'Hantera nummerlucka'
-  } else if (/trial balance/i.test(blocker)) {
+  } else if (/trial balance|råbalansen/i.test(blocker)) {
     href = '/reports/trial-balance'
     actionLabel = 'Öppna balansrapport'
-  } else if (/continuity/i.test(blocker)) {
+  } else if (/continuity|IB\/UB-kontinuiteten/i.test(blocker)) {
     href = '/bookkeeping'
     actionLabel = 'Granska ingående balans'
+  } else if (/unbooked transaction|saknar bokföring/i.test(blocker)) {
+    href = '/transactions'
+    actionLabel = 'Visa transaktioner'
   }
 
   return (


### PR DESCRIPTION
## Problem

The "Innan inlämning till Bolagsverket" warning list was rendered inside the blurred + `inert` coming-soon wrapper, so in the default config (`NEXT_PUBLIC_BOLAGSVERKET_FILING_ENABLED` unset) users could not read their own validation warnings — while the draft-PDF button right next to them stayed sharp and active. The comment above the wrapper states the intent was to keep the heading, instruction text and PDF button sharp; the warning list was swept in as collateral.

## Fix

The warning list moves out of the blurred wrapper. Those warnings describe problems in the user's own report (unmapped accounts, resultat vs 2099, AGM dates) and apply to the paper-PDF path just as much as to digital submission. Only the digital-inlämning explainer paragraph stays blurred while direct submission is gated.

## Scope reduced

This PR originally also patched `PreflightStep`'s blocker-link regexes. That hunk is **removed** in favour of **#1420**, which solves the same dead-link problem properly with stable blocker codes instead of regex string matching — and correctly drops the `/bookkeeping/voucher-gaps` branch, since that path exists only as an API route (`app/api/bookkeeping/voucher-gaps`), meaning this PR's regex fix would have made a link render that navigates nowhere. The two PRs no longer touch the same file.

Related: #1414 (readiness blockers), #1420 (typed blocker codes + link rendering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)