### PR TITLE
fix(whatsapp-inbox): name both ways to route receipts for multi-company senders

### DIFF
--- a/extensions/general/whatsapp-inbox/__tests__/messages-copy.test.ts
+++ b/extensions/general/whatsapp-inbox/__tests__/messages-copy.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { botCopy } from '@/extensions/general/whatsapp-inbox/lib/messages'
+
+/**
+ * Copy contracts that a rewrite must not quietly break. These assert the
+ * PROMISE the message makes to the user, not its exact wording: rephrasing
+ * is fine, dropping one of the two routing options is not.
+ */
+describe('m3Linked, multi-company sender', () => {
+  for (const locale of ['sv', 'en'] as const) {
+    it(`${locale}: names BOTH ways to route receipts`, () => {
+      const msg = botCopy(locale).m3Linked({ companyName: 'Arcim Technology AB', companyCount: 7 })
+
+      // Option 1: a default company set in the panel.
+      expect(msg).toMatch(locale === 'sv' ? /standardföretag/i : /default company/i)
+      // Option 2: per receipt, answered right after each one. Field feedback
+      // 2026-08-05: the old copy named only option 1, which read as if the
+      // per-receipt path did not exist.
+      expect(msg).toMatch(locale === 'sv' ? /ett kvitto i taget/i : /one receipt at a time/i)
+    })
+
+    it(`${locale}: keeps the routing guidance out of the AI-disclosure paragraph`, () => {
+      // Run together they read as a single sentence, which is how a real
+      // user mis-read the disclosure. Own paragraph, always.
+      const msg = botCopy(locale).m3Linked({ companyName: 'Arcim Technology AB', companyCount: 7 })
+      const disclosureParagraph = msg.split('\n\n').find((p) => /AI[- ]assistant|AI-assistent/i.test(p))
+      expect(disclosureParagraph).toBeDefined()
+      expect(disclosureParagraph).not.toMatch(/standardföretag|default company/i)
+    })
+  }
+
+  it('says nothing about company routing when the sender has exactly one company', () => {
+    const msg = botCopy('sv').m3Linked({ companyName: 'Arcim Technology AB', companyCount: 1 })
+    expect(msg).not.toMatch(/standardföretag/i)
+    expect(msg).toMatch(/AI-assistent/)
+  })
+})

--- a/extensions/general/whatsapp-inbox/lib/messages.ts
+++ b/extensions/general/whatsapp-inbox/lib/messages.ts
@@ -77,9 +77,13 @@ const SV = {
       'Två tips: skicka som _dokument_ (gem-ikonen) för bästa skärpa, och en fil per kvitto. Flersidiga kvitton skickas som PDF.'
     const outro =
       'Jag är en AI-assistent. Skriv *hjälp* för mänsklig support, *stopp* för att koppla från.'
+    // Two real ways to route a receipt, and the old copy named only one,
+    // which read as if the per-receipt path did not exist. Own paragraph:
+    // run together with the outro it read as a single sentence.
     const multi =
       companyCount > 1
-        ? `Du är med i ${companyCount} företag i Accounted. Välj standardföretag i panelen så hamnar kvitton rätt. `
+        ? `Du är med i ${companyCount} företag i Accounted. Välj antingen ett standardföretag i panelen, ` +
+          'eller skicka ett kvitto i taget så frågar jag vilket företag det gäller direkt efter varje kvitto.\n\n'
         : ''
     return `${intro}\n\n${tips}\n\n${multi}${outro}`
   },
@@ -206,7 +210,8 @@ const EN: typeof SV = {
       'I am an AI assistant. Type *hjälp* for human support, *stopp* to disconnect.'
     const multi =
       companyCount > 1
-        ? `You belong to ${companyCount} companies in Accounted. Pick a default company in the panel so receipts land in the right one. `
+        ? `You belong to ${companyCount} companies in Accounted. Either pick a default company in the panel, ` +
+          'or send one receipt at a time and I will ask which company it belongs to right after each one.\n\n'
         : ''
     return `${intro}\n\n${tips}\n\n${multi}${outro}`
   },


### PR DESCRIPTION
Field feedback from the first live WhatsApp receipt.

## What was wrong

The link confirmation told a multi-company sender only this:

> Du är med i 7 företag i Accounted. Välj standardföretag i panelen så hamnar kvitton rätt.

That names one of the two routing options and omits the one that actually runs by default. If no default company is set, the bot asks which company right after each receipt, which works well (it was exercised in the live test) but the copy made it look unsupported.

Second problem: this ran together with the AI disclosure into a single paragraph, so on a phone it reads as one sentence. The user came away believing the bot had described itself as a "mänsklig AI-assistent" (it actually says "Jag är en AI-assistent" then "Skriv *hjälp* för mänsklig support").

## After

> Du är med i 7 företag i Accounted. Välj antingen ett standardföretag i panelen, eller skicka ett kvitto i taget så frågar jag vilket företag det gäller direkt efter varje kvitto.
>
> Jag är en AI-assistent. Skriv *hjälp* för mänsklig support, *stopp* för att koppla från.

English variant updated to match. The single-company message is unchanged (it never mentioned routing and still does not).

## Test

New `messages-copy.test.ts` asserts the *promise* rather than the wording: both options named, disclosure kept in its own paragraph, single-company message silent about routing. Rephrasing stays free; dropping an option fails. Mutation-checked by restoring the old copy, which turns the test red.

## Verification
- `npm test`: 12665 passed
- `npm run lint`: 0 errors
- `npx tsc --noEmit`: 417, exactly the main baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Clarified WhatsApp inbox guidance for linked accounts with multiple companies.
  - Explained both default-company routing and selecting a company for each receipt in Swedish and English.

- **Bug Fixes**
  - Improved message formatting by separating routing guidance from AI disclosure information.
  - Removed unnecessary company-routing guidance for senders associated with only one company.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->