### PR TITLE
chore(nav): hide Korjournal from the sidebar

### DIFF
--- a/components/dashboard/DashboardNav.tsx
+++ b/components/dashboard/DashboardNav.tsx
@@ -45,7 +45,6 @@ import {
   PanelLeftClose,
   Library,
   BookCheck,
-  Car,
 } from 'lucide-react'
 import { getBranding } from '@/lib/branding/service'
 import { ENABLED_EXTENSION_IDS as _ENABLED_EXTENSION_IDS } from '@/lib/extensions/_generated/enabled-extensions'
@@ -194,7 +193,8 @@ const navItems: NavItem[] = [
   { href: '/invoices', labelKey: 'invoices', icon: ReceiptText, group: 'arbeta' },
   { href: '/supplier-invoices', labelKey: 'supplier_invoices', icon: Wallet, group: 'arbeta' },
   { href: '/salary', labelKey: 'salary', icon: HandCoins, group: 'arbeta', employerOnly: true },
-  { href: '/mileage', labelKey: 'mileage', icon: Car, group: 'arbeta' },
+  // Körjournal is deliberately hidden from the nav; the /mileage route stays live.
+  // { href: '/mileage', labelKey: 'mileage', icon: Car, group: 'arbeta' },
   // Analys: read the numbers.
   { href: '/kpi', labelKey: 'kpi', icon: TrendingUp, group: 'analys' },
   { href: '/reports', labelKey: 'reports', icon: BarChart3, group: 'analys' },


### PR DESCRIPTION
Hides the Korjournal (mileage) entry from the dashboard sidebar. The /mileage route and all mileage functionality remain live and reachable by URL; this only removes the nav item (and the now-unused Car icon import).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified the dashboard navigation by removing the unused mileage menu item.
  * The mileage page remains accessible through its existing route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->