### PR TITLE
feat(registry): add Bank Statement Sheet MCP server

### DIFF
--- a/registry/authors/alimpolat.mdx
+++ b/registry/authors/alimpolat.mdx
@@ -1,0 +1,19 @@
+---
+handle: "alimpolat"
+name: "Alim Polat"
+kind: "founder"
+bio: "Bygger bankstatementsheet.com — PDF-kontoutdrag till Excel, CSV och OFX, avstämt mot utdragets egna tryckta siffror innan något lämnar systemet."
+url: "https://bankstatementsheet.com"
+location: "Stockholm"
+joinedAt: "2026-08-08"
+---
+
+Jag bygger bankstatementsheet.com från Stockholm. Produkten gör en sak: läser ett
+PDF-kontoutdrag och kontrollräknar resultatet mot utdragets egna siffror innan
+det går vidare.
+
+Anledningen till att avstämningen är hela poängen och inte en detalj: fel som ser
+rimliga ut är värre än fel som syns. En extraktion som tappar en rad ger dig ett
+tal som ser ut som ett saldo, och det upptäcks först vid bokslutet. Därför är
+domen alltid med i svaret, och därför hålls raderna tillbaka när den inte går
+ihop.

--- a/registry/authors/alimpolat.mdx
+++ b/registry/authors/alimpolat.mdx
@@ -2,7 +2,7 @@
 handle: "alimpolat"
 name: "Alim Polat"
 kind: "founder"
-bio: "Bygger bankstatementsheet.com — PDF-kontoutdrag till Excel, CSV och OFX, avstämt mot utdragets egna tryckta siffror innan något lämnar systemet."
+bio: "Bygger bankstatementsheet.com: PDF-kontoutdrag till Excel, CSV och OFX, avstämt mot utdragets egna tryckta siffror innan något lämnar systemet."
 url: "https://bankstatementsheet.com"
 location: "Stockholm"
 joinedAt: "2026-08-08"

--- a/registry/entries/bank-statement-sheet-mcp.mdx
+++ b/registry/entries/bank-statement-sheet-mcp.mdx
@@ -1,0 +1,132 @@
+---
+title: "Bank Statement Sheet MCP-server"
+description: "MCP-server som läser PDF-kontoutdrag och lämnar tillbaka transaktionerna tillsammans med en avstämningsdom. Varje konvertering kontrollräknas mot utdragets egna tryckta siffror: löpande saldo där banken skriver ut ett, kontosummor där den inte gör det. Går det inte ihop hålls raderna tillbaka helt och en agent måste be om dem explicit. Tänkt som steget före bankimporten — CSV:n som kommer ut läses in under Bankfil."
+slug: "bank-statement-sheet-mcp"
+kind: "mcp"
+author: "alimpolat"
+status: "beta"
+lang: "sv"
+personas: ["developer", "byra", "finance"]
+publishedAt: "2026-08-08"
+updatedAt: "2026-08-08"
+installCommand: "npx -y bank-statement-sheet-mcp"
+externalUrl: "https://bankstatementsheet.com"
+version: "0.1.0"
+requiresWriteScope: false
+related: ["gnubok-mcp"]
+ogImageEyebrow: "MCP-server"
+faq:
+  - q: "Vad gör den som en vanlig PDF-extraktion inte gör?"
+    a: "Den kontrollräknar. Där utdraget skriver ut ett löpande saldo kontrolleras varje angränsande radpar: saldo plus belopp ska bli föregående saldo. Där det inte finns något saldo summeras raderna mot utdragets egna kontosummor. Domen följer med i svaret, och under tröskeln lämnas inga rader ut."
+  - q: "Skriver den något till accounted?"
+    a: "Nej. Servern anropar inga accounted-verktyg och behöver inga scopes. Den producerar en fil som du själv läser in under Bankfil. Kedjan mot gnubok_create_voucher är nästa steg och är inte byggd."
+  - q: "Var hamnar min PDF?"
+    a: "Den laddas upp över HTTPS till Bank Statement Sheets API, som kör i EU. Filen behandlas i minnet, uppladdningsposter raderas inom 24 timmar och transaktioner sparas inte permanent. Vill du inte att en fil lämnar maskinen ska du inte skicka in den."
+  - q: "Vad kostar det?"
+    a: "Utan API-nyckel gäller gratisnivån: 5 konverteringar per månad, Excel och CSV. Med nyckel gäller samma plan och dagliga sidgräns som kontot den tillhör. Nyckeln skapas på bankstatementsheet.com/dashboard."
+  - q: "Hur vet jag att den funkar mot accounted?"
+    a: "Testat mot sandlådan 2026-08-07: 14 av 14 transaktioner in under Bankfil, inkomster 35 500 kr och utgifter −23 540,86 kr på öret. Med semikolon som avgränsare och kommadecimal blev det noll varningar och noll överhoppade rader."
+---
+
+## Vad den gör
+
+Servern tar en sökväg till ett PDF-kontoutdrag och returnerar transaktionerna
+plus en dom om huruvida siffrorna går ihop. Ett anrop räcker: uppladdning,
+avstämning, rader och eventuella filer i samma svar.
+
+Poängen är inte extraktionen. Poängen är att du får veta när extraktionen är fel,
+innan raderna används till något. Ett utdrag där en rad tappats bort ger tal som
+ser rimliga ut, och det upptäcks först långt senare.
+
+## Avstämningen
+
+Två metoder, och vilken som används beror på utdraget:
+
+| Metod | När | Vad som kontrolleras |
+|---|---|---|
+| `balance-continuity` | Banken skriver ut ett löpande saldo | För varje angränsande radpar ska saldo plus belopp bli föregående saldo. Minst 99 procent av paren måste stämma. |
+| `control-total` | Inget saldo per rad | Raderna summeras mot utdragets egna kontosummor: ingående saldo, in, ut, utgående saldo. |
+
+Domen gäller **filen**, inte enskilda rader. Varje returnerad rad bär filens dom
+med sig, så markeringen överlever att raderna delas upp i separata verifikat —
+det är vidarebefordran av filens dom, inte en kontroll per rad. Inget exportformat
+har någon per-rad-markering.
+
+Går det inte ihop är `transactions` satt till null. Raderna finns kvar, men en
+agent måste be om dem explicit med `include_unverified_rows`, och det syns i
+transkriptet. Det är avsiktligt: en agent som skickar vidare det den fick ska
+inte kunna råka skicka vidare något overifierat.
+
+På vårt referensutdrag från Handelsbanken på 16 sidor går 742 av 742 kontroller
+ihop. Det är ett resultat på ett utdrag, inte en träffsäkerhetssiffra, och
+Handelsbanken är den enda bank vi publicerar en siffra för.
+
+## Installera
+
+Kräver Node 20 eller senare. Servern är stdio.
+
+```json
+{
+  "mcpServers": {
+    "bank-statement-sheet": {
+      "command": "npx",
+      "args": ["-y", "bank-statement-sheet-mcp"],
+      "env": {
+        "BSS_API_KEY": "bss_live_..."
+      }
+    }
+  }
+}
+```
+
+`BSS_API_KEY` är valfri. Utan nyckel körs gratisnivån, som är fullt fungerande
+för att prova. Nyckel skapas på bankstatementsheet.com/dashboard.
+
+Vill du se den köra utan att skicka in egna bankdata finns ett påhittat
+exempelutdrag inbyggt: sätt `use_demo_statement` till true.
+
+## Verktygen
+
+| Verktyg | Vad det gör |
+|---|---|
+| `convert_bank_statement` | PDF in, dom plus rader plus valfria filer ut, i ett anrop. |
+| `export_conversion` | Skriver en tidigare konvertering till fil i ett annat format. |
+| `check_account_status` | Vilken nivå och kvot anropet faktiskt körs på. |
+
+`check_account_status` finns för ett specifikt fel: en felstavad nyckel som tyst
+degraderas till anonym ger en server som verkar fungera tills kvoten tar slut
+utan förklaring. Kör den en gång per session.
+
+## Så använder du den mot accounted idag
+
+Manuellt, och det är värt att vara tydlig med:
+
+1. Konvertera utdraget. Be om CSV med semikolon och kommadecimal — det är vad
+   svenska importer läser utan varningar.
+2. Kontrollera domen. Är den `unverified` ska filen inte läsas in.
+3. Läs in CSV:n under Bankfil i accounted.
+4. Godkänn de stagade transaktionerna som vanligt.
+
+Steg 3 är en människa som flyttar en fil mellan två produkter. Det är hela
+integrationen i dagsläget.
+
+## Vad den inte gör
+
+- **Den skriver inget till accounted.** Inga accounted-verktyg anropas, inga
+  scopes begärs, ingenting stagas åt dig. Kedjan mot `gnubok_create_voucher` är
+  nästa steg och är inte byggd.
+- **Den kör inte lokalt.** PDF:en laddas upp till ett API i EU. Motorn ligger
+  serversidan; npm-paketet är en tunn HTTP-klient under MIT.
+- **Den läser inte från URL.** Bara lokala sökvägar, och bara inom en
+  tillåten katalog. En agent som blivit promptinjicerad ska inte kunna be
+  servern ladda upp en godtycklig fil från din disk.
+- **Den producerar ingen SIE och ingen CAMT.053.** Excel, CSV, JSON, OFX och
+  Fortnox-CSV är vad som finns. PDF till CAMT.053 vore en rakare väg in än CSV,
+  särskilt för utländska banker, men är inte byggt.
+
+## En ärlig begränsning
+
+Versionen är 0.1.0 och publicerades 2026-08-08. Den är verifierad mot
+produktion och mot accounteds sandlåda, men den har inga externa användare än.
+Hittar du något som inte stämmer vill jag gärna veta det — det är hela
+anledningen till att domen finns med i svaret istället för i marknadsföringen.

--- a/registry/entries/bank-statement-sheet-mcp.mdx
+++ b/registry/entries/bank-statement-sheet-mcp.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Bank Statement Sheet MCP-server"
-description: "MCP-server som läser PDF-kontoutdrag och lämnar tillbaka transaktionerna tillsammans med en avstämningsdom. Varje konvertering kontrollräknas mot utdragets egna tryckta siffror: löpande saldo där banken skriver ut ett, kontosummor där den inte gör det. Går det inte ihop hålls raderna tillbaka helt och en agent måste be om dem explicit. Tänkt som steget före bankimporten — CSV:n som kommer ut läses in under Bankfil."
+description: "MCP-server som läser PDF-kontoutdrag och lämnar tillbaka transaktionerna tillsammans med en avstämningsdom. Varje konvertering kontrollräknas mot utdragets egna tryckta siffror: löpande saldo där banken skriver ut ett, kontosummor där den inte gör det. Går det inte ihop hålls raderna tillbaka helt och en agent måste be om dem explicit. Tänkt som steget före bankimporten: CSV:n som kommer ut läses in under Bankfil."
 slug: "bank-statement-sheet-mcp"
 kind: "mcp"
 author: "alimpolat"
@@ -47,10 +47,14 @@ Två metoder, och vilken som används beror på utdraget:
 | `balance-continuity` | Banken skriver ut ett löpande saldo | För varje angränsande radpar ska saldo plus belopp bli föregående saldo. Minst 99 procent av paren måste stämma. |
 | `control-total` | Inget saldo per rad | Raderna summeras mot utdragets egna kontosummor: ingående saldo, in, ut, utgående saldo. |
 
-Domen gäller **filen**, inte enskilda rader. Varje returnerad rad bär filens dom
-med sig, så markeringen överlever att raderna delas upp i separata verifikat —
-det är vidarebefordran av filens dom, inte en kontroll per rad. Inget exportformat
-har någon per-rad-markering.
+Domen gäller **filen**, inte enskilda rader. Varje rad i MCP-svaret bär med sig
+filens dom, så att en agent som delar upp raderna inte tappar bort den på vägen.
+Det är vidarebefordran av filens dom, inte en kontroll per rad.
+
+Men domen lever bara i MCP-svaret. Så fort raderna skrivs till en fil finns ingen
+markering kvar per rad, och ingenting som importeras till accounted bär med sig
+domen. Den som läser in filen måste alltså ha sett domen innan, inte förvänta sig
+att hitta den i bokföringen efteråt.
 
 Går det inte ihop är `transactions` satt till null. Raderna finns kvar, men en
 agent måste be om dem explicit med `include_unverified_rows`, och det syns i
@@ -101,7 +105,7 @@ utan förklaring. Kör den en gång per session.
 
 Manuellt, och det är värt att vara tydlig med:
 
-1. Konvertera utdraget. Be om CSV med semikolon och kommadecimal — det är vad
+1. Konvertera utdraget. Be om CSV med semikolon och kommadecimal. Det är vad
    svenska importer läser utan varningar.
 2. Kontrollera domen. Är den `unverified` ska filen inte läsas in.
 3. Läs in CSV:n under Bankfil i accounted.
@@ -115,8 +119,9 @@ integrationen i dagsläget.
 - **Den skriver inget till accounted.** Inga accounted-verktyg anropas, inga
   scopes begärs, ingenting stagas åt dig. Kedjan mot `gnubok_create_voucher` är
   nästa steg och är inte byggd.
-- **Den kör inte lokalt.** PDF:en laddas upp till ett API i EU. Motorn ligger
-  serversidan; npm-paketet är en tunn HTTP-klient under MIT.
+- **Konverteringen sker inte lokalt.** Själva MCP-servern kör på din maskin över
+  stdio, men den är en tunn HTTP-klient under MIT: PDF:en laddas upp till ett API
+  i EU, och motorn ligger kvar på serversidan.
 - **Den läser inte från URL.** Bara lokala sökvägar, och bara inom en
   tillåten katalog. En agent som blivit promptinjicerad ska inte kunna be
   servern ladda upp en godtycklig fil från din disk.
@@ -128,5 +133,5 @@ integrationen i dagsläget.
 
 Versionen är 0.1.0 och publicerades 2026-08-08. Den är verifierad mot
 produktion och mot accounteds sandlåda, men den har inga externa användare än.
-Hittar du något som inte stämmer vill jag gärna veta det — det är hela
+Hittar du något som inte stämmer vill jag gärna veta det. Det är hela
 anledningen till att domen finns med i svaret istället för i marknadsföringen.


### PR DESCRIPTION
# What and why

Adds an MCP server to the community registry, plus the author profile it references (first contribution, so both files are in the same PR per `registry/README.md`).

**Bank Statement Sheet MCP** converts a PDF bank statement into transaction data that arrives with a pass/fail reconciliation verdict. Each file is checked against its own printed figures — balance continuity where the bank prints a running balance, footing against the statement's control totals where it does not. Below the threshold the rows are withheld entirely and an agent has to ask for them explicitly, so unverified figures cannot reach a voucher by accident.

Why it may be useful here: the bank import covers CAMT.053, CSV and PSD2, but a PDF has no way in — and PSD2 only solves forwards, while a migration off another system is backwards by definition. This is the step before the import.

Verified against the sandbox on 2026-08-07: 14 of 14 transactions imported under Bankfil, Inkomster 35 500 kr and Utgifter −23 540,86 kr matching to the öre. The semicolon + comma-decimal export imports with zero warnings and zero skipped rows.

Scope, stated plainly: it **writes nothing to accounted and requests no scopes**. It produces a file the user imports themselves. Chaining to `gnubok_create_voucher` is the obvious next step and is not built yet — the entry says so rather than implying otherwise. `status` is `beta` because the package was published 2026-08-08 and has no external users yet.

Install: `npx -y bank-statement-sheet-mcp` (MIT). A synthetic sample statement is built in, so it can be tried without uploading real bank data.

## Checklist

- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat(registry):`)
- [x] `npm run validate:registry` passes locally — **21 entries, 3 authors, 0 failures**
- [x] Commits are signed off (`git commit -s`, see DCO)
- [ ] `npm run lint`, `npm test` and `npm run build` — **not run.** Documentation-only change: two `.mdx` files, no code paths touched. Happy to run them if you would rather I did.
- [ ] New or changed logic in `lib/` or `app/` has tests — n/a, no logic
- [ ] New or changed UI strings in both `messages/sv.json` and `messages/en.json` — n/a, no UI strings
- [ ] Migrations are new files in `supabase/migrations/` — n/a, no migrations
- [ ] Core builds with zero extensions enabled — n/a, no imports added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an author profile for Alim Polat, including background information, Stockholm location, website, join date, and Swedish biography.
  - Added a Swedish registry entry for the beta bank statement MCP server.
  - Documented PDF bank-statement conversion, balance verification, transaction handling, installation, available tools, data practices, file restrictions, unsupported formats, and known limitations.
  - Clarified that inconsistent or unverified transaction results are withheld.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->