### PR TITLE
feat(banking): the bank-connect payoff

### DIFF
--- a/app/(dashboard)/transactions/page.tsx
+++ b/app/(dashboard)/transactions/page.tsx
@@ -22,6 +22,7 @@ import BankSyncStatusChip from '@/components/transactions/BankSyncStatusChip'
 import { ContextPicker, type ContextPickerItem } from '@/components/common/ContextPicker'
 import { AttnLine } from '@/components/ui/attn-line'
 import BankSyncNowButton from '@/components/transactions/BankSyncNowButton'
+import BankSyncSinceLastVisit from '@/components/transactions/BankSyncSinceLastVisit'
 import TransactionInboxCard from '@/components/transactions/TransactionInboxCard'
 import TransactionHistoryList from '@/components/transactions/TransactionHistoryList'
 import InboxZeroState from '@/components/transactions/InboxZeroState'
@@ -2663,6 +2664,7 @@ export default function TransactionsPage() {
         )}
         <BankSyncStatusChip />
         <BankSyncNowButton />
+        <BankSyncSinceLastVisit />
         <Link
           href="/reports/bank-reconciliation"
           className="ml-auto transition-colors duration-150 hover:text-foreground"

--- a/components/transactions/BankSyncSinceLastVisit.tsx
+++ b/components/transactions/BankSyncSinceLastVisit.tsx
@@ -43,8 +43,11 @@ export default function BankSyncSinceLastVisit() {
       .eq('company_id', company.id)
       .eq('import_source', 'enable_banking')
       .gt('created_at', lastVisitRaw)
-      .then(({ count: rowCount }) => {
+      .then(({ count: rowCount, error }) => {
         if (cancelled) return
+        // A failed query must not advance the marker: that would silently
+        // swallow the notification for rows that DID arrive in the window.
+        if (error) return
         if (rowCount && rowCount > 0) {
           setCount(rowCount)
         } else {

--- a/extensions/general/enable-banking/components/BankSyncProgressDialog.tsx
+++ b/extensions/general/enable-banking/components/BankSyncProgressDialog.tsx
@@ -83,6 +83,30 @@ export function BankSyncProgressDialog({
   // grace period the user may background the (still-running) sync.
   const blockClose = state.kind === 'syncing' && !overGrace
 
+  // The payoff: once the first sync lands, name the work now waiting so the
+  // moment points onward instead of stranding the user on the settings panel.
+  // Same authenticated endpoint the dashboard pane refetches; best-effort.
+  const [workCounts, setWorkCounts] = useState<{ book: number; matches: number } | null>(null)
+  useEffect(() => {
+    if (!open || state.kind !== 'done' || state.summary.imported === 0) return
+    let cancelled = false
+    fetch('/api/worklist/counts')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((json: { data?: { counts?: Record<string, number> } } | null) => {
+        if (cancelled || !json?.data?.counts) return
+        setWorkCounts({
+          book: json.data.counts.book_transaction ?? 0,
+          matches: json.data.counts.suggested_match ?? 0,
+        })
+      })
+      .catch(() => {
+        // The CTA degrades to a plain link; the numbers are a nicety.
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [open, state])
+
   return (
     <Dialog
       open={open}
@@ -152,7 +176,7 @@ export function BankSyncProgressDialog({
         )}
 
         {state.kind === 'done' && (
-          <DoneBody summary={state.summary} />
+          <DoneBody summary={state.summary} workCounts={workCounts} />
         )}
 
         {state.kind === 'failed' && (
@@ -162,22 +186,47 @@ export function BankSyncProgressDialog({
         )}
 
         <DialogFooter>
-          <Button
-            type="button"
-            onClick={() => onOpenChange(false)}
-            disabled={blockClose}
-          >
-            {state.kind === 'syncing'
-              ? (overGrace ? 'Fortsätt i bakgrunden' : 'Hämtar…')
-              : 'Klar'}
-          </Button>
+          {state.kind === 'done' && state.summary.imported > 0 ? (
+            <>
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => onOpenChange(false)}
+              >
+                Stäng
+              </Button>
+              <Button asChild>
+                <Link href="/transactions">
+                  {workCounts && workCounts.book > 0
+                    ? `Visa ${workCounts.book} att bokföra`
+                    : 'Öppna transaktionerna'}
+                </Link>
+              </Button>
+            </>
+          ) : (
+            <Button
+              type="button"
+              onClick={() => onOpenChange(false)}
+              disabled={blockClose}
+            >
+              {state.kind === 'syncing'
+                ? (overGrace ? 'Fortsätt i bakgrunden' : 'Hämtar…')
+                : 'Klar'}
+            </Button>
+          )}
         </DialogFooter>
       </DialogContent>
     </Dialog>
   )
 }
 
-function DoneBody({ summary }: { summary: SyncProgressSummary }) {
+function DoneBody({
+  summary,
+  workCounts,
+}: {
+  summary: SyncProgressSummary
+  workCounts: { book: number; matches: number } | null
+}) {
   const requestedDays = daysBetween(summary.requested_from)
   const returnedDays =
     summary.returned_min_date && summary.returned_max_date
@@ -197,6 +246,12 @@ function DoneBody({ summary }: { summary: SyncProgressSummary }) {
           {summary.returned_min_date && summary.returned_max_date && (
             <p className="text-xs text-muted-foreground">
               Datum: {summary.returned_min_date} → {summary.returned_max_date}
+            </p>
+          )}
+          {workCounts && workCounts.book > 0 && (
+            <p className="mt-1 text-xs text-muted-foreground tabular-nums">
+              {workCounts.book} att bokföra
+              {workCounts.matches > 0 && <> · {workCounts.matches} matchar fakturor</>}
             </p>
           )}
         </div>

--- a/extensions/general/enable-banking/components/BankSyncProgressDialog.tsx
+++ b/extensions/general/enable-banking/components/BankSyncProgressDialog.tsx
@@ -88,7 +88,11 @@ export function BankSyncProgressDialog({
   // Same authenticated endpoint the dashboard pane refetches; best-effort.
   const [workCounts, setWorkCounts] = useState<{ book: number; matches: number } | null>(null)
   useEffect(() => {
-    if (!open || state.kind !== 'done' || state.summary.imported === 0) return
+    if (!open || state.kind !== 'done' || state.summary.imported === 0) {
+      // A later sync must not inherit the previous run's numbers.
+      setWorkCounts(null)
+      return
+    }
     let cancelled = false
     fetch('/api/worklist/counts')
       .then((res) => (res.ok ? res.json() : null))


### PR DESCRIPTION
Fifth activation slice (after #1461, #1468, #1471, #1473 — all merged). The concept's "Nuet kopplas in" payoff, landed on the one surface every successful bank connect actually passes through.

## The insight (from the flow scout)
The OAuth callback hardcodes its return to `/settings/banking`, and the first transaction sync runs inside the account-picker save with `BankSyncProgressDialog` awaiting it — so that dialog's **done state** is the guaranteed payoff moment. It previously ended on a bare "Klar" that closed the dialog and stranded the user on the settings panel with no pointer to their new transactions.

## What changes
- **Done state names the waiting work**: under "N nya transaktioner importerade", a quiet line "{book} att bokföra · {matches} matchar fakturor" — fetched once from the existing authenticated `/api/worklist/counts` (same endpoint the dashboard's Att göra pane refetches; best-effort, silent on failure).
- **Primary action points onward**: "Visa N att bokföra" → `/transactions` (label degrades to "Öppna transaktionerna" if the counts fetch failed), with a quiet "Stäng" beside it. Zero-import syncs keep the old plain "Klar".
- **Orphan rescued**: `BankSyncSinceLastVisit` — a fully-built "N nya transaktioner sedan sist" pill counting nightly-synced rows per company — existed with i18n keys in both locales and was mounted **nowhere**. It now sits in the transactions footer next to the sync status chip, giving returning users the same payoff line for the cron.

## Gates
`npm test`: 13 379 passed · tsc clean in touched files · lint 0 errors · no new i18n keys needed (dialog strings stay hardcoded Swedish per extension convention; the pill's keys already existed) · package-lock untouched · no migrations, no API changes.

Click-through: connect a bank (or run Synka nu → the dialog) and check the done state's CTA; then revisit /transactions the day after a nightly sync for the pill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “sync since last visit” option to the transaction controls.
  * Sync completion now displays bookkeeping and invoice-matching counts when available.
  * Added a direct option to view imported transactions after synchronization.

* **Improvements**
  * Updated the sync completion dialog to retain a close option alongside the new transaction action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->