### PR TITLE
fix(auth): serve /docs and llms.txt to anonymous agents

### DIFF
--- a/lib/supabase/__tests__/middleware.test.ts
+++ b/lib/supabase/__tests__/middleware.test.ts
@@ -249,6 +249,32 @@ describe('updateSession redirect destinations', () => {
     })
   })
 
+  // ── Public agent-discovery + docs surfaces ────────────────────────────
+
+  describe('anonymous access to agent-discovery and docs surfaces', () => {
+    it.each(['/llms.txt', '/llms-full.txt', '/docs/api', '/docs/api.md', '/docs/api/reference.md', '/docs/api/cookbook/quickstart.md'])(
+      'serves %s without a login bounce',
+      async (path) => {
+        const response = await run(path)
+        expect(response.status).not.toBe(307)
+        expect(locationOf(response)).toBeNull()
+      },
+    )
+
+    it('does not treat a /docs prefix on another route as public', async () => {
+      // /docsy-dashboard must still bounce: only /docs and /docs/* are public.
+      const response = await run('/docsy-dashboard')
+      expect(response.status).toBe(307)
+      expect(new URL(locationOf(response)!).pathname).toBe('/login')
+    })
+
+    it('serves docs to a signed-in user without redirecting away', async () => {
+      state.user = SIGNED_IN
+      const response = await run('/docs/api')
+      expect(response.status).not.toBe(307)
+    })
+  })
+
   // ── Site 1: protected-route bounce ────────────────────────────────────
 
   describe('protected route bounce to /login', () => {

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -201,6 +201,23 @@ export async function updateSession(request: NextRequest) {
     return supabaseResponse
   }
 
+  // Public agent-discovery + API docs surfaces. /llms.txt and /llms-full.txt
+  // exist FOR anonymous consumers (the llms.txt convention targets logged-out
+  // crawlers and IDE agents), and /docs is the public API documentation the
+  // OpenAPI spec and the installable accounted-api skill link to. None of it
+  // reads the session. Without this branch every anonymous hit 307-bounced to
+  // /login, which silently broke agent discovery on the hosted product
+  // (openapi.json only escaped because the proxy matcher skips .json paths).
+  // Logged-in users fall through to the same content: no redirect either way.
+  if (
+    pathname === '/llms.txt' ||
+    pathname === '/llms-full.txt' ||
+    pathname === '/docs' ||
+    pathname.startsWith('/docs/')
+  ) {
+    return supabaseResponse
+  }
+
   // Public auth routes: allow access
   if (
     pathname.startsWith('/login') ||


### PR DESCRIPTION
## What

Anonymous requests to `/llms.txt`, `/llms-full.txt`, and `/docs/*` have been 307-bouncing to `/login` on hosted, because the middleware's public-path allowlist never included them. Found while live-verifying #1516: the docs link in the API landing and every agent-discovery surface except `openapi.json` (which escapes via the proxy matcher's `.json` exclusion) was login-gated.

These surfaces exist for logged-out consumers by design (llms.txt convention, public API docs referenced by the OpenAPI spec and the installable `accounted-api` skill). None of them read the session.

## Change

One early-return branch in `updateSession` for `/llms.txt`, `/llms-full.txt`, `/docs`, `/docs/*`. Signed-in users get the same content, no redirect-away (unlike the auth pages branch). Prefix matching is exact-segment (`/docsy-x` still bounces).

## Tests

New middleware cases: each surface serves anonymously without a bounce, `/docs`-prefix lookalikes still bounce, signed-in users are not redirected away. 35/35 middleware tests green; guards + lint ratchets pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public access to documentation pages and AI-readable content files without requiring sign-in.

* **Bug Fixes**
  * Prevented authenticated users from being redirected away from documentation pages.
  * Ensured only valid documentation paths bypass access restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->