### PR TITLE
fix(inbox): say each thing once, and stop explaining what doing it teaches

### DIFF
--- a/app/(dashboard)/pending/page.tsx
+++ b/app/(dashboard)/pending/page.tsx
@@ -304,7 +304,47 @@ function formatRelativeTime(dateStr: string): string {
   return `${diffDays} dagar sedan`
 }
 
+/**
+ * Account number -> account name, for the proposal previews.
+ *
+ * A preview line showed the account number next to the line's own description,
+ * so "5890 Utlägg Norwegian" hid the fact that 5890 is Övriga resekostnader.
+ * The number alone is not readable and the description is not the account, so
+ * approving meant trusting a label that never named what was being debited.
+ *
+ * Fetched once per page and shared: every preview on screen wants the same map.
+ */
+let accountNamesPromise: Promise<Record<string, string>> | null = null
+
+function useAccountNames(): Record<string, string> {
+  const [names, setNames] = useState<Record<string, string>>({})
+  useEffect(() => {
+    let alive = true
+    accountNamesPromise ??= fetch('/api/bookkeeping/accounts')
+      .then((r) => r.json())
+      .then(({ data }) =>
+        Object.fromEntries(
+          ((data ?? []) as Array<{ account_number: string; account_name: string }>).map((a) => [
+            a.account_number,
+            a.account_name,
+          ]),
+        ),
+      )
+      // A failed lookup must not blank the preview: the number still shows.
+      .catch(() => ({}))
+    void accountNamesPromise.then((m) => {
+      if (alive) setNames(m)
+    })
+    return () => {
+      alive = false
+    }
+  }, [])
+  return names
+}
+
+
 function CategorizePreview({ data }: { data: Record<string, unknown> }) {
+  const accountNames = useAccountNames()
   // The exact journal lines the approval will post (net cost line, VAT line,
   // gross bank line, SEK) — staged by the server since the preview-lines fix.
   const lines = (data.lines as Array<{ account_number?: string; debit_amount?: number; credit_amount?: number; description?: string }>) || []
@@ -319,7 +359,21 @@ function CategorizePreview({ data }: { data: Record<string, unknown> }) {
           const creditAmt = typeof line.credit_amount === 'number' ? line.credit_amount : 0
           return (
             <div key={i} className="flex justify-between gap-4 font-mono text-xs">
-              <span className="truncate">{line.account_number ?? '?'}{line.description ? ` ${line.description}` : ''}</span>
+              <span className="truncate">
+                {line.account_number ?? '?'}{' '}
+                {/* The account's own name first: it is what the posting means.
+                    The line text follows only when it adds something the name
+                    does not already say. */}
+                <span className="text-foreground">
+                  {(line.account_number && accountNames[line.account_number]) || line.description || ''}
+                </span>
+                {line.description &&
+                line.account_number &&
+                accountNames[line.account_number] &&
+                line.description !== accountNames[line.account_number] ? (
+                  <span className="text-muted-foreground"> · {line.description}</span>
+                ) : null}
+              </span>
               <span className="tabular-nums shrink-0">
                 {debitAmt > 0 ? `D ${formatCurrency(debitAmt)}` : `K ${formatCurrency(creditAmt)}`}
               </span>
@@ -369,7 +423,14 @@ function CategorizePreview({ data }: { data: Record<string, unknown> }) {
           <p className="text-xs text-muted-foreground mb-1">Momsrader</p>
           {vatLines.map((line, i) => (
             <div key={i} className="flex justify-between font-mono text-xs">
-              <span>{line.account_number} {line.description}</span>
+              <span>
+                {line.account_number}{' '}
+                {accountNames[line.account_number] || line.description}
+                {accountNames[line.account_number] &&
+                line.description !== accountNames[line.account_number] ? (
+                  <span className="text-muted-foreground"> · {line.description}</span>
+                ) : null}
+              </span>
               <span className="tabular-nums">
                 {line.debit_amount > 0 ? `D ${formatCurrency(line.debit_amount)}` : `K ${formatCurrency(line.credit_amount)}`}
               </span>

--- a/app/(dashboard)/pending/page.tsx
+++ b/app/(dashboard)/pending/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useCallback, useMemo, Fragment } from 'react'
+import { useState, useEffect, useCallback, useMemo, Fragment, createContext, useContext } from 'react'
 import { useTranslations } from 'next-intl'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -312,29 +312,34 @@ function formatRelativeTime(dateStr: string): string {
  * The number alone is not readable and the description is not the account, so
  * approving meant trusting a label that never named what was being debited.
  *
- * Fetched once per page and shared: every preview on screen wants the same map.
+ * Owned by the page rather than a module-level cache: the map is per company,
+ * and a cache that outlives the page would keep serving one company's account
+ * names after a switch. A failed fetch leaves the map empty, which shows the
+ * bare number rather than a wrong name, and retries on the next mount.
  */
-let accountNamesPromise: Promise<Record<string, string>> | null = null
+const AccountNamesContext = createContext<Record<string, string>>({})
 
-function useAccountNames(): Record<string, string> {
+function useAccountNamesSource(): Record<string, string> {
   const [names, setNames] = useState<Record<string, string>>({})
   useEffect(() => {
     let alive = true
-    accountNamesPromise ??= fetch('/api/bookkeeping/accounts')
+    void fetch('/api/bookkeeping/accounts')
       .then((r) => r.json())
-      .then(({ data }) =>
-        Object.fromEntries(
-          ((data ?? []) as Array<{ account_number: string; account_name: string }>).map((a) => [
-            a.account_number,
-            a.account_name,
-          ]),
-        ),
-      )
-      // A failed lookup must not blank the preview: the number still shows.
-      .catch(() => ({}))
-    void accountNamesPromise.then((m) => {
-      if (alive) setNames(m)
-    })
+      .then(({ data }) => {
+        if (!alive) return
+        setNames(
+          Object.fromEntries(
+            ((data ?? []) as Array<{ account_number: string; account_name: string }>).map((a) => [
+              a.account_number,
+              a.account_name,
+            ]),
+          ),
+        )
+      })
+      .catch(() => {
+        // Display-only: the number still shows, so a failure is not worth
+        // surfacing as an error the user cannot act on.
+      })
     return () => {
       alive = false
     }
@@ -344,7 +349,7 @@ function useAccountNames(): Record<string, string> {
 
 
 function CategorizePreview({ data }: { data: Record<string, unknown> }) {
-  const accountNames = useAccountNames()
+  const accountNames = useContext(AccountNamesContext)
   // The exact journal lines the approval will post (net cost line, VAT line,
   // gross bank line, SEK) — staged by the server since the preview-lines fix.
   const lines = (data.lines as Array<{ account_number?: string; debit_amount?: number; credit_amount?: number; description?: string }>) || []
@@ -814,6 +819,7 @@ type ViewTab = 'pending' | 'history'
 
 export default function PendingOperationsPage() {
   const t = useTranslations('pending')
+  const accountNames = useAccountNamesSource()
   const [operations, setOperations] = useState<PendingOperation[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [activeTab, setActiveTab] = useState<ViewTab>('pending')
@@ -1185,6 +1191,7 @@ export default function PendingOperationsPage() {
   ]
 
   return (
+    <AccountNamesContext.Provider value={accountNames}>
     <div className="space-y-8">
       {/* Page header (concept scene 11): title + Godkänn alla */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
@@ -1765,5 +1772,6 @@ export default function PendingOperationsPage() {
         </DialogContent>
       </Dialog>
     </div>
+    </AccountNamesContext.Provider>
   )
 }

--- a/components/bookkeeping/JournalEntryForm.tsx
+++ b/components/bookkeeping/JournalEntryForm.tsx
@@ -1855,9 +1855,6 @@ export default function JournalEntryForm({
             {t('save_as_template')}
           </Button>
         </div>
-        <p className="mt-1.5 text-xs text-muted-foreground">
-          {t('fill_balance_hint')} {t('keyboard_hint')}
-        </p>
       </div>
 
       {/* Document attachments: hidden when editing a draft; underlag is

--- a/components/extensions/general/EditKonteringDialog.tsx
+++ b/components/extensions/general/EditKonteringDialog.tsx
@@ -30,7 +30,6 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
-  DialogDescription,
 } from '@/components/ui/dialog'
 
 export interface ProposedLine {
@@ -74,9 +73,6 @@ export default function EditKonteringDialog({
       <DialogContent className="max-w-6xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Ändra kontering</DialogTitle>
-          <DialogDescription>
-            Förslaget är en utgångspunkt. Ändra konto, belopp, datum eller serie innan du bokför.
-          </DialogDescription>
         </DialogHeader>
 
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,480px)]">
@@ -87,12 +83,21 @@ export default function EditKonteringDialog({
               // props once, by design.
               key={itemId}
               embedded
-              initialLines={lines.map((l) => ({
-                account_number: l.account_number,
-                debit_amount: l.debit_amount ? String(l.debit_amount) : '',
-                credit_amount: l.credit_amount ? String(l.credit_amount) : '',
-                line_description: l.description,
-              }))}
+              // An unknown supplier has no proposal, and passing [] here is
+              // not the same as passing nothing: the form seeds two blank rows
+              // only when this is undefined, so an empty array opened the
+              // dialog with no rows at all and a "lägg till rad" between the
+              // user and typing anything.
+              initialLines={
+                lines.length > 0
+                  ? lines.map((l) => ({
+                      account_number: l.account_number,
+                      debit_amount: l.debit_amount ? String(l.debit_amount) : '',
+                      credit_amount: l.credit_amount ? String(l.credit_amount) : '',
+                      line_description: l.description,
+                    }))
+                  : undefined
+              }
               initialDate={entryDate}
               initialDescription={description}
               submitUrl={`/api/extensions/ext/invoice-inbox/items/${itemId}/book-direct`}

--- a/components/extensions/general/InvoiceInboxWorkspace.tsx
+++ b/components/extensions/general/InvoiceInboxWorkspace.tsx
@@ -568,10 +568,23 @@ export default function InvoiceInboxWorkspace(_props: WorkspaceComponentProps) {
     hunting,
     progress: huntProgress,
     result: huntResult,
+    setResult: setHuntResult,
   } = useReceiptHunt(() => {
     void fetchItems()
     void fetchPurchases()
   })
+
+  // A run that found nothing leaves nothing to act on, so the line has no
+  // reason to outlive the glance that reads it. A run that found something,
+  // or failed, stays: both name a next step (press again, or a mailbox to
+  // check) and both are worth still being on screen a minute later.
+  useEffect(() => {
+    if (hunting || !huntResult) return
+    if (huntResult.failed || huntResult.fetched > 0) return
+    const timer = setTimeout(() => setHuntResult(null), 6000)
+    return () => clearTimeout(timer)
+  }, [hunting, huntResult, setHuntResult])
+
 
   const selectedPurchase = useMemo(
     () => purchases.find((p) => p.id === selectedPurchaseId) ?? null,
@@ -2506,8 +2519,7 @@ const SUGGESTION_SOURCE_LABEL: Record<string, string> = {
 
 /** Why there is no proposal, said plainly rather than shown as an empty table. */
 const SUGGESTION_EMPTY_REASON: Record<string, string> = {
-  no_mapping:
-    'Vi har inget förslag: leverantören är obekant och ingen regel matchar. Bokför manuellt en gång, så känns den igen nästa gång.',
+  no_mapping: 'Okänd leverantör. Bokför en gång, så känns den igen.',
   currency_unsupported:
     'Köpet är i utländsk valuta och matchades av en konteringsregel. Momsen skulle bli fel, så vi visar inget förslag.',
 }
@@ -2907,9 +2919,8 @@ function FieldsRail({
       {/* Hint only: creation happens on the leverantörsfaktura form via "Skapa & välj" */}
       {showNoMatchHint && (
         <div className="border-b bg-muted/30 px-4 py-2 text-xs text-muted-foreground">
-          Ingen leverantör matchade{' '}
           <span className="text-foreground font-medium">{extractedSupplierName}</span>
-          {': leverantören skapas när du klickar Skapa leverantörsfaktura.'}
+          {' finns inte upplagd än. Den skapas när du gör leverantörsfakturan.'}
         </div>
       )}
 
@@ -3039,19 +3050,6 @@ function FieldsRail({
             {/* Matched-to-tx state: show the bridge to booking. The user
                 picks one of two actions: book themselves with the
                 deterministic dialog, or hand off to the assistant. */}
-            <div className="rounded-md border border-success/30 bg-success/5 px-3 py-2 text-xs">
-              <div className="flex items-center gap-1.5 text-success font-medium mb-1">
-                <Link2 className="h-3 w-3" />
-                Matchad mot transaktion
-              </div>
-              <Link
-                href={`/transactions?highlight=${item.matched_transaction_id}`}
-                className="text-muted-foreground hover:text-foreground hover:underline"
-              >
-                Öppna transaktionen →
-              </Link>
-            </div>
-
             {onAskAssistant && (
               <Button
                 variant="default"
@@ -3176,12 +3174,26 @@ function FieldsRail({
             Bokförd
           </Badge>
         )}
-        {isLinkedToTransaction && (
-          <Badge variant="secondary" className="w-full justify-center text-[10px]">
-            <Link2 className="h-2.5 w-2.5 mr-1" />
-            Kopplad till transaktion
-          </Badge>
-        )}
+        {isLinkedToTransaction &&
+          (item.matched_transaction_id ? (
+            <Link
+              href={`/transactions?highlight=${item.matched_transaction_id}`}
+              className="w-full"
+            >
+              <Badge
+                variant="secondary"
+                className="w-full justify-center text-[10px] hover:bg-secondary/80"
+              >
+                <Link2 className="h-2.5 w-2.5 mr-1" />
+                Kopplad till transaktion
+              </Badge>
+            </Link>
+          ) : (
+            <Badge variant="secondary" className="w-full justify-center text-[10px]">
+              <Link2 className="h-2.5 w-2.5 mr-1" />
+              Kopplad till transaktion
+            </Badge>
+          ))}
       </div>
       )}
 

--- a/components/extensions/general/InvoiceInboxWorkspace.tsx
+++ b/components/extensions/general/InvoiceInboxWorkspace.tsx
@@ -2138,21 +2138,26 @@ function OnboardingCard({
   isActivating,
   compact = false,
 }: OnboardingCardProps) {
+  // The card described the page as it was before the underlag rebuild: three
+  // steps ending at "matcha eller bokför", with no mention that the page now
+  // searches the mailboxes itself, lists the purchases that are missing a
+  // receipt, or proposes the kontering. It also carried a Beta badge it had
+  // outgrown.
   const steps = [
     {
       done: hasInboxAddress,
       title: 'Aktivera din inkorgsadress',
-      hint: 'Få en unik e-postadress som leverantörer kan skicka fakturor och kvitton till.',
+      hint: 'En egen adress som leverantörer kan fakturera direkt, och som du kan vidarebefordra kvitton till.',
     },
     {
       done: hasAnyItem,
-      title: 'Ladda upp eller maila in ett underlag',
-      hint: 'Accounted tolkar fakturan eller kvittot åt dig och fyller i fält automatiskt.',
+      title: 'Koppla en brevlåda, maila in, eller ladda upp',
+      hint: 'Med en kopplad brevlåda letar Kvittojakten själv upp kvitton till köp som saknar underlag. Utan den fyller du på för hand.',
     },
     {
       done: hasResolvedItem,
-      title: 'Matcha mot en transaktion eller bokför',
-      hint: 'Eller skapa en manuell transaktion om underlaget saknar bankhändelse.',
+      title: 'Godkänn konteringen',
+      hint: 'Matchade underlag får ett förslag på hur de bokförs, utifrån hur du bokfört samma leverantör förut. Du granskar och bokför.',
     },
   ]
   // First incomplete step drives the active CTA. Falls back to -1 if all done
@@ -2183,16 +2188,15 @@ function OnboardingCard({
               compact ? 'text-sm' : 'text-lg'
             )}
           >
-            Så funkar dokumentinkorgen
+            Så funkar Underlag
           </h2>
-          <Badge variant="secondary" className="text-[10px] uppercase tracking-wider">
-            Beta
-          </Badge>
         </div>
         <p className={cn('text-muted-foreground', compact ? 'text-[11px]' : 'text-xs')}>
-          Underlagen samlas här (från mail eller filuppladdning) och kan
-          matchas mot bankhändelser eller bokföras direkt. Inkorgen är alltid
-          gratis; AI-tolkning av underlag ingår i abonnemanget.
+          Här samlas underlagen, och här syns köpen som saknar ett. Kvittojakten
+          söker igenom kopplade brevlådor efter kvitton du inte fått in, och
+          matchade underlag får ett förslag på kontering att godkänna. Att samla
+          underlag är alltid gratis; AI-tolkning och kvittojakt ingår i
+          abonnemanget.
         </p>
       </div>
 

--- a/components/extensions/general/MailConnectionsPanel.tsx
+++ b/components/extensions/general/MailConnectionsPanel.tsx
@@ -129,7 +129,7 @@ export function MailConnectionsPanel() {
                 </span>
               }
             >
-              <span className="truncate">{connection.emailAddress}</span>
+              <span className="min-w-0 flex-1 truncate">{connection.emailAddress}</span>
               {connection.status === 'needs_reconsent' ? (
                 <Badge variant="warning">{t('needs_reconsent')}</Badge>
               ) : null}

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -326,7 +326,7 @@
   "mail": {
     "hunt_stop": "Stoppa",
     "hunt_progress": "{fetched} hämtade…",
-    "hunt_title": "Leta efter underlag",
+    "hunt_title": "Kvittojakten",
     "hunt_help": "Vi söker i de kopplade brevlådorna efter kvitton och fakturor till köp som saknar underlag, läser beloppet ur filen och lägger fram förslagen i Granskning. Inget bokförs.",
     "hunt_row": "Sök igenom brevlådorna",
     "hunt_action": "Leta nu",


### PR DESCRIPTION
Six things the page said that it didn't need to say, or said twice. All found by looking at it.

## Alignment

The mailbox rows in Settings misaligned whenever an address was long: the address span couldn't shrink, so the date and **Koppla från** wrapped onto a second line while the provider mark stayed vertically centred against a now two-line row. `min-w-0` lets `truncate` actually do its job.

Also, the group was labelled **Leta efter underlag** directly above a row labelled **Sök igenom brevlådorna** — the same sentence twice. The group is now **Kvittojakten**, which is what the rest of the app calls it.

## Things that outstayed their welcome

- A hunt that found nothing left *"Inga nya underlag i brevlådorna"* on screen indefinitely. There's nothing to act on, so it now clears itself. A run that **found** something, or **failed**, still stays — both name a next step.
- *"Förslaget är en utgångspunkt. Ändra konto, belopp, datum eller serie innan du bokför."* restated the dialog's title and the fact that its fields are editable.
- The keyboard tips (`dubbelklicka på debet…`, `Enter hoppar till nästa fält…`) sat under **every** entry form permanently. A hint that never leaves stops being read.

## Two rows on open

**Ändra kontering** opened with *no rows at all* for an unknown supplier, so the first move was **Lägg till rad** before anything could be typed — with "Minst två rader krävs" showing in red underneath.

The form already defaults to two blank rows when given nothing. The dialog was passing an empty proposal as `[]`, and `[] ?? default` is not `undefined ?? default`.

## Said twice

The matched state appeared as both a bordered success box (*"Matchad mot transaktion / Öppna transaktionen →"*) and a badge (*"Kopplad till transaktion"*) in the same rail. The box is gone; the badge keeps the state **and takes over its link**, so the affordance survives.

## Verification

Build green, lint clean, guards clean, 23 tests pass. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Account names now appear in pending-operation categorization previews, with descriptions shown when relevant.
  - Invoice inbox searches with no matches now clear automatically after six seconds.
  - Matched transactions can be opened directly from the status badge.

- **Improvements**
  - Updated invoice inbox onboarding and messaging for clearer guidance.
  - Improved display of connected email addresses on smaller layouts.
  - Simplified journal entry and invoice dialog guidance.

- **Language**
  - Updated the Swedish receipt-search title to “Kvittojakten.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->