### PR TITLE
feat(inbox): show extracted fakturadatum on inbox cards

### DIFF
--- a/components/extensions/general/InvoiceInboxWorkspace.tsx
+++ b/components/extensions/general/InvoiceInboxWorkspace.tsx
@@ -1942,6 +1942,15 @@ function InboxRow({
   const hasUnansweredQuestion =
     !isBooked && item.channel_context?.pending_question?.status === 'moved_to_app'
 
+  const receivedMeta = (
+    <span className="truncate">
+      {timeAgo(item.email_received_at ?? item.created_at)}
+      {invoiceDate && (
+        <> · <span className="tabular-nums">{formatDate(invoiceDate)}</span></>
+      )}
+    </span>
+  )
+
   return (
     <li
       className={cn(
@@ -2021,20 +2030,10 @@ function InboxRow({
                   {t('wa_question_badge')}
                 </Badge>
               )}
-              <span className="truncate">
-                {timeAgo(item.email_received_at ?? item.created_at)}
-                {invoiceDate && (
-                  <> · <span className="tabular-nums">{formatDate(invoiceDate)}</span></>
-                )}
-              </span>
+              {receivedMeta}
             </span>
           ) : (
-            <span className="truncate">
-              {timeAgo(item.email_received_at ?? item.created_at)}
-              {invoiceDate && (
-                <> · <span className="tabular-nums">{formatDate(invoiceDate)}</span></>
-              )}
-            </span>
+            receivedMeta
           )}
           {!isPlaceholder && amount != null && (
             <span className="tabular-nums shrink-0">

--- a/components/extensions/general/InvoiceInboxWorkspace.tsx
+++ b/components/extensions/general/InvoiceInboxWorkspace.tsx
@@ -158,6 +158,10 @@ function pickSupplierName(item: InboxItem): string | null {
   return item.extracted_data?.supplier?.name ?? null
 }
 
+function pickInvoiceDate(item: InboxItem): string | null {
+  return item.extracted_data?.invoice?.invoiceDate ?? null
+}
+
 // True when extraction produced at least one usable field. Distinguishes a
 // deterministically-parsed underlag (fields present: render the editable
 // list) from an item whose extracted_data is null/empty (AI never ran, or ran
@@ -1926,6 +1930,7 @@ function InboxRow({
   const t = useTranslations('inbox_workspace')
   const amount = pickAmount(item)
   const supplierName = pickSupplierName(item)
+  const invoiceDate = pickInvoiceDate(item)
   const isPlaceholder = !!item.isPlaceholder
   const status = deriveInboxStatus(item)
   const isErrored = status === 'error'
@@ -2016,10 +2021,20 @@ function InboxRow({
                   {t('wa_question_badge')}
                 </Badge>
               )}
-              <span className="truncate">{timeAgo(item.email_received_at ?? item.created_at)}</span>
+              <span className="truncate">
+                {timeAgo(item.email_received_at ?? item.created_at)}
+                {invoiceDate && (
+                  <> · <span className="tabular-nums">{formatDate(invoiceDate)}</span></>
+                )}
+              </span>
             </span>
           ) : (
-            <span className="truncate">{timeAgo(item.email_received_at ?? item.created_at)}</span>
+            <span className="truncate">
+              {timeAgo(item.email_received_at ?? item.created_at)}
+              {invoiceDate && (
+                <> · <span className="tabular-nums">{formatDate(invoiceDate)}</span></>
+              )}
+            </span>
           )}
           {!isPlaceholder && amount != null && (
             <span className="tabular-nums shrink-0">


### PR DESCRIPTION
# What and why

User request: with many invoices from the same supplier in the invoice inbox, the cards are indistinguishable (supplier name, arrival time, and amount only). This appends the extracted invoice date after the arrival time on each card, rendered via formatDate() with tabular-nums, shown only when extraction produced a date. Display-only change in InvoiceInboxWorkspace.tsx; no schema, API, or re-extraction changes.

## Checklist

- [x] Title follows Conventional Commits
- [x] npm run lint passes locally (0 errors); check:guards clean
- [ ] New or changed logic in lib/ or app/api/ has tests (n/a: component-only change, outside test scope)
- [ ] New or changed UI strings (n/a: no new strings, renders a formatted date)
- [ ] Migrations (n/a: none)
- [x] Core builds with zero extensions enabled (component file, no core imports from @/extensions/)

Migrations: no.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added invoice date extraction and display in inbox rows.
  * Invoice dates appear alongside the received or created relative date when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->