### PR TITLE
fix(design): keep sortable table headers uppercase

### DIFF
--- a/app/(dashboard)/invoices/page.tsx
+++ b/app/(dashboard)/invoices/page.tsx
@@ -168,10 +168,12 @@ function SortableHeader({
       className={cn(TH_CLASS, className)}
       aria-sort={direction === 'asc' ? 'ascending' : direction === 'desc' ? 'descending' : 'none'}
     >
+      {/* Preflight sets text-transform: none on buttons, which would drop the
+          TH_CLASS uppercase idiom inside the sort control. */}
       <button
         type="button"
         className={cn(
-          '-mx-2 inline-flex min-h-10 items-center gap-1 rounded-sm px-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+          '-mx-2 inline-flex min-h-10 items-center gap-1 rounded-sm px-2 uppercase focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
           align === 'right' && 'ml-auto justify-end',
         )}
         aria-label={sortLabel}

--- a/components/bookkeeping/JournalEntryList.tsx
+++ b/components/bookkeeping/JournalEntryList.tsx
@@ -150,10 +150,12 @@ function SortableHeader({
       className={cn(TH_CLASS, className)}
       aria-sort={active ? (direction === 'asc' ? 'ascending' : 'descending') : 'none'}
     >
+      {/* Preflight sets text-transform: none on buttons, which would drop the
+          TH_CLASS uppercase idiom inside the sort control. */}
       <button
         type="button"
         className={cn(
-          '-mx-2 inline-flex min-h-10 items-center gap-1 rounded-sm px-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+          '-mx-2 inline-flex min-h-10 items-center gap-1 rounded-sm px-2 uppercase focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
           align === 'right' && 'ml-auto justify-end',
         )}
         aria-label={sortLabel}


### PR DESCRIPTION
Founder spotted that /bookkeeping's table heads (Verifikation, Datum, …) render sentence-case while /transactions renders uppercase. Both use `TH_CLASS` (11px uppercase), but the sortable variants wrap the label in a `<button>` — and Tailwind preflight sets `text-transform: none` on buttons, neutralizing the inherited uppercase. Plain-text headers were unaffected, hence the inconsistency.

Two-line fix: `uppercase` on the sort button in the two sortable-header components (JournalEntryList + invoices page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)