### PR TITLE
fix(import): SEB CSV imports survive BOMs and bad format choices

### DIFF
--- a/app/(dashboard)/import/page.tsx
+++ b/app/(dashboard)/import/page.tsx
@@ -240,8 +240,20 @@ function BankFileImportWizard() {
           description: `${txCount} transaktioner hittades`,
         })
       } else {
-        // Format detected but no transactions parsed: parser couldn't extract rows
-        setBankError('Filen kunde läsas men inga transaktioner hittades. Kontrollera att filen innehåller transaktionsdata och inte bara rubriker.')
+        // Format detected but no transactions parsed: surface the parser's
+        // real issues when it produced any, so the user sees WHY (wrong
+        // columns, invalid dates, ...) instead of only a generic hint.
+        const parseIssues: BankFileParseResult['issues'] = data.data.parse_result.issues ?? []
+        if (parseIssues.length > 0) {
+          setBankError(
+            parseIssues
+              .slice(0, 5)
+              .map((issue) => (issue.row > 0 ? `Rad ${issue.row}: ${issue.message}` : issue.message))
+              .join(' ')
+          )
+        } else {
+          setBankError('Filen kunde läsas men inga transaktioner hittades. Kontrollera att filen innehåller transaktionsdata och inte bara rubriker.')
+        }
       }
     } catch (err) {
       setBankError(err instanceof Error ? getErrorMessage(err) : 'Kunde inte läsa filen')

--- a/app/api/v1/companies/[companyId]/imports/bank/__tests__/route.test.ts
+++ b/app/api/v1/companies/[companyId]/imports/bank/__tests__/route.test.ts
@@ -278,6 +278,25 @@ describe('POST /api/v1/companies/:companyId/imports/bank', () => {
     }
   })
 
+  it('stamps ids and provenance with the fallback format when an explicit override parses nothing', async () => {
+    // Swedbank file forced as `seb`: the parser falls back to the detected
+    // format, and external ids / import_source must follow the format the
+    // result carries so they equal what the auto-detect path would produce.
+    const swedbankCsv = [
+      'Kontouppgifter',
+      'Clearingnummer,Kontonummer,Datum,Text,Belopp,Saldo',
+      '8123,12345678,2024-01-15,SPOTIFY AB,-99.00,12345.67',
+    ].join('\n')
+
+    const res = await callRoute({ fileContent: swedbankCsv, search: '?format=seb' })
+    expect(res.status).toBe(202)
+
+    const rows = ingestedRows()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].import_source).toBe('csv_swedbank')
+    expect(rows[0].external_id).toMatch(/^swedbank_/)
+  })
+
   it('never sends keys RawTransaction does not have (`source`, `counterparty`)', async () => {
     await callRoute()
 

--- a/app/api/v1/companies/[companyId]/imports/bank/route.ts
+++ b/app/api/v1/companies/[companyId]/imports/bank/route.ts
@@ -36,6 +36,7 @@ import {
   generateExternalId,
 } from '@/lib/import/bank-file/parser'
 import { ingestTransactions, type RawTransaction } from '@/lib/transactions/ingest'
+import { decodeFileContent } from '@/lib/import/shared/encoding'
 import type { BankFileFormatId } from '@/lib/import/bank-file/types'
 import { getErrorMessage as getUserErrorMessage } from '@/lib/errors/get-error-message'
 
@@ -158,13 +159,10 @@ export const POST = withApiV1<{ params: Promise<{ companyId: string }> }>(
       formatOverride = parsed.data
     }
 
-    // Decode the file. Bank files are typically Windows-1252 or UTF-8; we
-    // try UTF-8 first and fall back if invalid replacement chars appear.
+    // Decode the file with the shared importer decode (BOM-aware UTF-8 /
+    // UTF-16 / Windows-1252): one decode implementation for every path.
     const buffer = await file.arrayBuffer()
-    const utf8 = new TextDecoder('utf-8').decode(buffer)
-    const content = utf8.includes('�')
-      ? new TextDecoder('windows-1252').decode(buffer)
-      : utf8
+    const content = decodeFileContent(buffer)
 
     const fileHash = await generateFileHash(content)
 
@@ -178,6 +176,11 @@ export const POST = withApiV1<{ params: Promise<{ companyId: string }> }>(
     }
 
     const parseResult = parseBankFile(content, file.name, format)
+    // parseBankFile may fall back to a detected sibling format when an
+    // explicit override parses 0 transactions. Everything downstream (external
+    // ids, import_source, stored file_format) must use the format the result
+    // actually carries so ids equal what the auto-detect path would produce.
+    const effectiveFormat = parseResult.format
     const blockingIssues = parseResult.issues.filter((issue) => issue.severity === 'error')
     if (blockingIssues.length > 0) {
       // Cap the reported rows so a large malformed file cannot balloon the
@@ -195,7 +198,7 @@ export const POST = withApiV1<{ params: Promise<{ companyId: string }> }>(
     if (parseResult.transactions.length === 0) {
       return v1ErrorResponseFromCode('BANK_FILE_NO_TRANSACTIONS', ctx.log, {
         requestId: ctx.requestId,
-        details: { format, filename: file.name },
+        details: { format: effectiveFormat, filename: file.name },
       })
     }
 
@@ -208,7 +211,7 @@ export const POST = withApiV1<{ params: Promise<{ companyId: string }> }>(
         params: {
           filename: file.name,
           file_size: file.size,
-          format,
+          format: effectiveFormat,
           file_hash: fileHash,
           transaction_count: parseResult.transactions.length,
         },
@@ -232,7 +235,7 @@ export const POST = withApiV1<{ params: Promise<{ companyId: string }> }>(
             company_id: ctx.companyId!,
             filename: file.name,
             file_hash: fileHash,
-            file_format: format,
+            file_format: effectiveFormat,
             transaction_count: parseResult.transactions.length,
             status: 'processing',
             date_from: parseResult.date_from,
@@ -271,13 +274,13 @@ export const POST = withApiV1<{ params: Promise<{ companyId: string }> }>(
       // shared ingest contract, not in this route alone.
       const raw: RawTransaction[] = parseResult.transactions.map(
         (t, idx): RawTransaction => ({
-          external_id: generateExternalId(t, format, idx),
+          external_id: generateExternalId(t, effectiveFormat, idx),
           date: t.date,
           amount: t.amount,
           currency: t.currency || 'SEK',
           description: t.description,
           reference: t.reference ?? null,
-          import_source: format === 'camt053' ? 'camt053' : `csv_${format}`,
+          import_source: effectiveFormat === 'camt053' ? 'camt053' : `csv_${effectiveFormat}`,
         }),
       )
 
@@ -329,7 +332,7 @@ export const POST = withApiV1<{ params: Promise<{ companyId: string }> }>(
         {
           id: op.id,
           result: {
-            format,
+            format: effectiveFormat,
             file_hash: fileHash,
             transactions_imported: ingestResult.imported,
             transactions_duplicates: ingestResult.duplicates,

--- a/app/api/v1/companies/[companyId]/imports/bank/route.ts
+++ b/app/api/v1/companies/[companyId]/imports/bank/route.ts
@@ -3,7 +3,8 @@
  *
  * Bank-file import. Multipart upload: the file is the request body. The
  * route:
- *   1. Decodes the file (UTF-8 / Windows-1252 auto-detected).
+ *   1. Decodes the file (UTF-8 / UTF-16 / Windows-1252 auto-detected;
+ *      BOMs handled at the byte level).
  *   2. Detects the bank file format (SEB / Swedbank / Nordea / Handelsbanken
  *      / Lansforsakringar / Lunar / ICA Banken / Skandia / CAMT053 /
  *      Nordea Business / Wise / generic CSV), or honors the optional `format`
@@ -55,7 +56,7 @@ registerEndpoint({
   path: '/api/v1/companies/:companyId/imports/bank',
   summary: 'Import a bank-file (CSV / XML / CAMT053).',
   description:
-    'Accepts a bank statement file (UTF-8 / Windows-1252, up to 10 MB) as multipart/form-data. Auto-detects the bank format (SEB, Swedbank, Handelsbanken, Nordea, Nordea Business, Lansforsakringar, Lunar, ICA Banken, Skandia, Wise transaction history, Wise balance statement, CAMT053, generic CSV) or honors a `format` override. Parses transactions, ingests them into the `transactions` table (NOT into journal entries: see BFL note in pitfalls), and emits `transaction.synced` events. Returns operation_id for polling.',
+    'Accepts a bank statement file (UTF-8 / UTF-16 / Windows-1252, up to 10 MB) as multipart/form-data. Auto-detects the bank format (SEB, Swedbank, Handelsbanken, Nordea, Nordea Business, Lansforsakringar, Lunar, ICA Banken, Skandia, Wise transaction history, Wise balance statement, CAMT053, generic CSV) or honors a `format` override. Parses transactions, ingests them into the `transactions` table (NOT into journal entries: see BFL note in pitfalls), and emits `transaction.synced` events. Returns operation_id for polling.',
   useWhen:
     'Importing a bank statement export for a period. Common with PSD2 bank connections that don\'t auto-sync, or for legacy bank accounts.',
   doNotUseFor:

--- a/lib/import/bank-file/__tests__/parser.test.ts
+++ b/lib/import/bank-file/__tests__/parser.test.ts
@@ -1389,7 +1389,9 @@ describe('parseBankFile: camt.053 XML format', () => {
 
 describe('parseBankFile: explicit format override', () => {
   it('uses the specified format instead of auto-detection', () => {
-    // Force parsing Nordea content as SEB (will produce issues but should use SEB format)
+    // Nordea content forced as SEB: the widened SEB parser handles it via
+    // delimiter sniffing + the bare-Datum tier, and a working explicit parse
+    // is never overridden by the auto-detect fallback.
     const result = parseBankFile(
       'Datum,Transaktion,Kategori,Belopp,Saldo\n2024-01-15,Test,,"-100,00","5000,00"',
       'nordea.csv',
@@ -1397,6 +1399,8 @@ describe('parseBankFile: explicit format override', () => {
     )
 
     expect(result.format).toBe('seb')
+    expect(result.transactions).toHaveLength(1)
+    expect(result.transactions[0].amount).toBe(-100)
   })
 
   it('returns error for unknown formatId', () => {
@@ -1407,7 +1411,7 @@ describe('parseBankFile: explicit format override', () => {
     expect(result.transactions).toHaveLength(0)
     expect(result.issues).toHaveLength(1)
     expect(result.issues[0].severity).toBe('error')
-    expect(result.issues[0].message).toContain('Unknown format')
+    expect(result.issues[0].message).toContain('Okänt format')
   })
 
   it('returns format detection error when no format matches and no override given', () => {
@@ -1427,6 +1431,131 @@ describe('parseBankFile: explicit format override', () => {
     // generic_csv uses a default mapping (date=0, description=1, amount=2)
     // But the first line is treated as header (skip_rows=1), so only second row is data
     expect(result.format).toBe('generic_csv')
+  })
+})
+
+describe('parseBankFile: explicit format fallback to auto-detection', () => {
+  it('falls back to the detected format when the explicit choice parses 0 transactions', () => {
+    const result = parseBankFile(SWEDBANK_CSV, 'export.csv', 'seb')
+
+    expect(result.format).toBe('swedbank')
+    expect(result.transactions).toHaveLength(3)
+    expect(result.issues[0].severity).toBe('info')
+    expect(result.issues[0].message).toContain('SEB')
+    expect(result.issues[0].message).toContain('Swedbank')
+  })
+
+  it('falls back to Handelsbanken when a Handelsbanken file is forced as SEB', () => {
+    const result = parseBankFile(HANDELSBANKEN_CSV, 'export.csv', 'seb')
+
+    expect(result.format).toBe('handelsbanken')
+    expect(result.transactions).toHaveLength(3)
+    expect(result.issues[0].severity).toBe('info')
+    expect(result.issues[0].message).toContain('Handelsbanken')
+  })
+
+  it('never overrides a working explicit parse even when detection prefers another format', () => {
+    // NORDEA_CSV auto-detects as nordea, but forced-SEB parses it fine via
+    // delimiter sniffing + the bare-Datum tier: the user's choice stands.
+    expect(detectFileFormat(NORDEA_CSV, 'nordea.csv')!.id).toBe('nordea')
+
+    const result = parseBankFile(NORDEA_CSV, 'nordea.csv', 'seb')
+
+    expect(result.format).toBe('seb')
+    expect(result.transactions).toHaveLength(3)
+    expect(result.issues.filter((i) => i.severity === 'info')).toHaveLength(0)
+  })
+
+  it('keeps the explicit error result when no other format can parse the file', () => {
+    const result = parseBankFile(UNKNOWN_CSV, 'unknown.csv', 'seb')
+
+    expect(result.format).toBe('seb')
+    expect(result.transactions).toHaveLength(0)
+    expect(result.issues[0].severity).toBe('error')
+    expect(result.issues[0].message).toContain('Kunde inte identifiera nödvändiga kolumner')
+  })
+
+  it('does not fall back for explicit generic_csv (the manual mapping escape hatch)', () => {
+    // The default generic mapping parses 0 rows of a Nordea file, but the
+    // user chose "Annan CSV" to map columns manually: never reroute them.
+    const result = parseBankFile(NORDEA_CSV, 'nordea.csv', 'generic_csv')
+
+    expect(result.format).toBe('generic_csv')
+  })
+})
+
+describe('parseBankFile: BOM handling', () => {
+  it('auto-detects and parses SEB CSV with a real UTF-8 BOM (U+FEFF)', () => {
+    const content = '\uFEFF' + SEB_CSV
+
+    expect(detectFileFormat(content, 'seb.csv')!.id).toBe('seb')
+
+    const result = parseBankFile(content, 'seb.csv')
+    expect(result.format).toBe('seb')
+    expect(result.transactions).toHaveLength(3)
+  })
+
+  it('auto-detects and parses SEB privat CSV with a mojibake BOM prefix', () => {
+    const content = 'ï»¿' + SEB_PRIVAT_CSV
+
+    expect(detectFileFormat(content, 'kontoutdrag.csv')!.id).toBe('seb')
+
+    const result = parseBankFile(content, 'kontoutdrag.csv')
+    expect(result.format).toBe('seb')
+    expect(result.transactions).toHaveLength(3)
+  })
+
+  it('detects an exact-match Datum header behind a mojibake BOM prefix', () => {
+    // Exact-match header checks (h === 'datum') are the genuinely BOM-fragile
+    // ones: a surviving mojibake prefix used to make this file undetectable.
+    const content = 'ï»¿' + [
+      'Datum;Text;Belopp;Saldo',
+      '2026-01-15;SPOTIFY AB;-99,00;1000,00',
+    ].join('\n')
+
+    const format = detectFileFormat(content, 'export.csv')
+    expect(format).not.toBeNull()
+    expect(format!.id).toBe('nordea_business')
+
+    const result = parseBankFile(content, 'export.csv')
+    expect(result.transactions).toHaveLength(1)
+    expect(result.transactions[0].amount).toBe(-99)
+  })
+})
+
+describe('parseBankFile: SEB delimiter sniffing and bare-Datum tier', () => {
+  it('parses a comma-delimited SEB-labeled file under explicit seb', () => {
+    const commaSeb = [
+      'Bokföringsdag,Valutadag,Verifikationsnummer,Text,Belopp,Saldo',
+      '2024-01-15,2024-01-15,12345,SPOTIFY AB,"-99,00","12345,67"',
+      '2024-01-14,2024-01-14,12346,HEMKÖP,"-432,50","12444,67"',
+    ].join('\n')
+
+    const result = parseBankFile(commaSeb, 'seb.csv', 'seb')
+
+    expect(result.format).toBe('seb')
+    expect(result.transactions).toHaveLength(2)
+    expect(result.transactions[0].amount).toBe(-99)
+    expect(result.transactions[0].description).toBe('SPOTIFY AB')
+    expect(result.transactions[0].balance).toBe(12345.67)
+  })
+
+  it('parses a bare-Datum layout under explicit seb without claiming it in detect', () => {
+    const bareDatum = [
+      'Datum;Text;Belopp;Saldo',
+      '2026-02-01;SPOTIFY AB;-99,00;1000,00',
+      '2026-02-02;LÖN;25000,00;26000,00',
+    ].join('\n')
+
+    // detect must NOT claim the bare-Datum layout: in auto-detection it
+    // belongs to other profiles (nordea_business format D family).
+    expect(getFormat('seb')!.detect(bareDatum, 'seb.csv')).toBe(false)
+
+    const result = parseBankFile(bareDatum, 'seb.csv', 'seb')
+
+    expect(result.format).toBe('seb')
+    expect(result.transactions).toHaveLength(2)
+    expect(result.transactions[1].amount).toBe(25000)
   })
 })
 

--- a/lib/import/bank-file/formats/seb.ts
+++ b/lib/import/bank-file/formats/seb.ts
@@ -1,7 +1,8 @@
 /**
  * SEB CSV format parser
  *
- * Format: Semicolon-delimited, comma decimal separator
+ * Format: Semicolon-delimited, comma decimal separator (parse also accepts
+ *   comma-delimited variants via delimiter sniffing; detect stays strict)
  * Columns vary but typically: Bokföringsdag, Valutadag, Verifikationsnummer,
  *   Text/mottagare, Belopp, Saldo
  * Date format: YYYY-MM-DD
@@ -11,6 +12,7 @@
 import type { BankFileFormat, BankFileParseResult, ParsedBankTransaction, BankFileParseIssue } from '../types'
 import { prepareContent } from '../../shared/encoding'
 import { normalizeDate } from '../date-utils'
+import { parseCSVLine } from './nordea'
 
 function parseCommaDecimal(value: string): number {
   const cleaned = value.replace(/\s/g, '').replace(',', '.')
@@ -43,12 +45,25 @@ export const sebFormat: BankFileFormat = {
     const issues: BankFileParseIssue[] = []
     let skippedRows = 0
 
-    // Parse header to find column indices
+    // Parse header to find column indices. SEB normally exports
+    // semicolon-delimited files, but some export surfaces use commas: sniff
+    // the delimiter from the header line instead of assuming ';'.
     const headerLine = lines[0] || ''
-    const headers = headerLine.split(';').map((h) => h.trim().toLowerCase().replace(/"/g, ''))
+    const semicolons = (headerLine.match(/;/g) || []).length
+    const commas = (headerLine.match(/,/g) || []).length
+    const delimiter = commas > semicolons ? ',' : ';'
+    const headers = parseCSVLine(headerLine, delimiter).map((h) =>
+      h.trim().toLowerCase().replace(/"/g, '')
+    )
 
     // Find column indices dynamically
-    const dateIdx = headers.findIndex((h) => /bokf(ö|o)ringsda(g|tum)/.test(h))
+    let dateIdx = headers.findIndex((h) => /bokf(ö|o)ringsda(g|tum)/.test(h))
+    if (dateIdx === -1) {
+      // Lowest-priority tier: a bare "Datum" column. Only honored here in
+      // parse (an explicit user choice), never in detect, so this profile
+      // cannot steal files from other bank profiles during auto-detection.
+      dateIdx = headers.findIndex((h) => h === 'datum')
+    }
     const descIdx = headers.findIndex(
       (h) => h.includes('text') || h.includes('mottagare') || h.includes('beskrivning')
     )
@@ -58,7 +73,7 @@ export const sebFormat: BankFileFormat = {
     if (dateIdx === -1 || amountIdx === -1) {
       issues.push({
         row: 1,
-        message: 'Could not identify required columns (date, amount)',
+        message: 'Kunde inte identifiera nödvändiga kolumner (datum, belopp)',
         severity: 'error',
       })
       return {
@@ -76,7 +91,7 @@ export const sebFormat: BankFileFormat = {
       const line = lines[i].trim()
       if (!line) continue
 
-      const fields = line.split(';').map((f) => f.trim().replace(/^"|"$/g, ''))
+      const fields = parseCSVLine(line, delimiter).map((f) => f.trim().replace(/^"|"$/g, ''))
 
       const date = fields[dateIdx]
       const description = fields[descIdx >= 0 ? descIdx : dateIdx + 1] || 'Unknown'
@@ -84,21 +99,21 @@ export const sebFormat: BankFileFormat = {
       const balanceStr = balanceIdx >= 0 ? fields[balanceIdx] : undefined
 
       if (!date || !amountStr) {
-        issues.push({ row: i + 1, message: 'Missing required fields', severity: 'warning' })
+        issues.push({ row: i + 1, message: 'Obligatoriska fält saknas', severity: 'warning' })
         skippedRows++
         continue
       }
 
       const amount = parseCommaDecimal(amountStr)
       if (isNaN(amount)) {
-        issues.push({ row: i + 1, message: `Invalid amount: ${amountStr}`, severity: 'warning' })
+        issues.push({ row: i + 1, message: `Ogiltigt belopp: ${amountStr}`, severity: 'warning' })
         skippedRows++
         continue
       }
 
       const normalizedDate = normalizeDate(date)
       if (!normalizedDate) {
-        issues.push({ row: i + 1, message: `Invalid date: ${date}`, severity: 'warning' })
+        issues.push({ row: i + 1, message: `Ogiltigt datum: ${date}`, severity: 'warning' })
         skippedRows++
         continue
       }

--- a/lib/import/bank-file/parser.ts
+++ b/lib/import/bank-file/parser.ts
@@ -97,10 +97,42 @@ export function parseBankFile(
         transactions: [],
         date_from: null,
         date_to: null,
-        issues: [{ row: 0, message: `Unknown format: ${formatId}`, severity: 'error' }],
+        issues: [{ row: 0, message: `Okänt format: ${formatId}`, severity: 'error' }],
         stats: { total_rows: 0, parsed_rows: 0, skipped_rows: 0, total_income: 0, total_expenses: 0 },
       }
     }
+
+    const explicitResult = format.parse(content)
+    if (explicitResult.transactions.length > 0 || formatId === 'generic_csv') {
+      // A working explicit parse is never overridden. generic_csv is also
+      // exempt: it is the manual column-mapping escape hatch and its default
+      // mapping legitimately parses 0 rows before the user maps columns.
+      return explicitResult
+    }
+
+    // The explicit choice parsed nothing: fall back to auto-detection so an
+    // explicitly selected bank is never WORSE than "Automatisk identifiering".
+    // detectFileFormat can never return generic_csv (its detect() is always
+    // false), so this cannot reroute the UI into the mapping flow.
+    const detected = detectFileFormat(content, filename)
+    if (detected && detected.id !== formatId) {
+      const detectedResult = detected.parse(content)
+      if (detectedResult.transactions.length > 0) {
+        return {
+          ...detectedResult,
+          issues: [
+            {
+              row: 0,
+              message: `Filen matchade inte det valda formatet (${format.name}) och tolkades istället som ${detected.name}.`,
+              severity: 'info',
+            },
+            ...detectedResult.issues,
+          ],
+        }
+      }
+    }
+
+    return explicitResult
   } else {
     format = detectFileFormat(content, filename) || undefined
     if (!format) {

--- a/lib/import/bank-file/types.ts
+++ b/lib/import/bank-file/types.ts
@@ -38,7 +38,7 @@ export interface BankFileParseResult {
 export interface BankFileParseIssue {
   row: number
   message: string
-  severity: 'warning' | 'error'
+  severity: 'info' | 'warning' | 'error'
 }
 
 /** Supported bank file format identifiers */

--- a/lib/import/shared/__tests__/encoding.test.ts
+++ b/lib/import/shared/__tests__/encoding.test.ts
@@ -5,6 +5,7 @@ import {
   hasEncodingIssues,
   recoverStringWithFFFD,
   recoverWordWithFFFD,
+  stripBOM,
 } from '../encoding'
 
 describe('decodeStringContent', () => {
@@ -77,6 +78,49 @@ describe('decodeFileContent', () => {
     // 0xD6 = Ö in Windows-1252; lone 0xD6 is not valid UTF-8 start byte
     const cp1252 = buf([0x47, 0xd6, 0x54, 0x45, 0x42, 0x4f, 0x52, 0x47])
     expect(decodeFileContent(cp1252)).toBe('GÖTEBORG')
+  })
+
+  it('strips a UTF-8 BOM (EF BB BF) and decodes the remainder as UTF-8', () => {
+    const payload = Array.from(new TextEncoder().encode('Bokföringsdag;Belopp'))
+    const text = decodeFileContent(buf([0xef, 0xbb, 0xbf, ...payload]))
+    expect(text).toBe('Bokföringsdag;Belopp')
+    expect(text.charCodeAt(0)).not.toBe(0xfeff)
+  })
+
+  it('never produces a mojibake BOM prefix when a BOM-ed file needs the Windows-1252 fallback', () => {
+    // 'Datum;' + 0xD6 (Ö in Windows-1252, invalid as a lone UTF-8 byte),
+    // behind a UTF-8 BOM. The BOM bytes must never re-enter the fallback
+    // decode, so the result starts with 'Datum', not the literal mojibake.
+    const bytes = buf([0xef, 0xbb, 0xbf, 0x44, 0x61, 0x74, 0x75, 0x6d, 0x3b, 0xd6])
+    const text = decodeFileContent(bytes)
+    expect(text.startsWith('ï»¿')).toBe(false)
+    expect(text).toBe('Datum;Ö')
+  })
+
+  it('decodes UTF-16LE content behind a FF FE BOM', () => {
+    // 'Öre' in UTF-16LE: d6 00, 72 00, 65 00
+    const bytes = buf([0xff, 0xfe, 0xd6, 0x00, 0x72, 0x00, 0x65, 0x00])
+    expect(decodeFileContent(bytes)).toBe('Öre')
+  })
+
+  it('decodes UTF-16BE content behind a FE FF BOM', () => {
+    const bytes = buf([0xfe, 0xff, 0x00, 0xd6, 0x00, 0x72, 0x00, 0x65])
+    expect(decodeFileContent(bytes)).toBe('Öre')
+  })
+})
+
+describe('stripBOM', () => {
+  it('strips a leading U+FEFF', () => {
+    expect(stripBOM('\uFEFF' + 'Datum;Belopp')).toBe('Datum;Belopp')
+  })
+
+  it('strips a leading literal mojibake BOM (ï»¿)', () => {
+    expect(stripBOM('ï»¿Datum;Belopp')).toBe('Datum;Belopp')
+  })
+
+  it('is a no-op on clean content and never strips mid-string', () => {
+    expect(stripBOM('Datum;Belopp')).toBe('Datum;Belopp')
+    expect(stripBOM('Datum;ï»¿Belopp')).toBe('Datum;ï»¿Belopp')
   })
 })
 

--- a/lib/import/shared/encoding.ts
+++ b/lib/import/shared/encoding.ts
@@ -7,12 +7,38 @@
  */
 
 /**
- * Decode file content, handling both UTF-8 and Windows-1252 encodings.
+ * Decode file content, handling BOMs plus UTF-8 and Windows-1252 encodings.
  *
- * Strategy: Try UTF-8 first. If the result contains replacement characters
- * (U+FFFD) or garbled Swedish chars, fall back to Windows-1252.
+ * Strategy: inspect the leading BYTES first.
+ * - FF FE / FE FF: UTF-16LE/BE (e.g. Excel "Unicode text" re-saves). Decode
+ *   as such; TextDecoder consumes the BOM itself.
+ * - EF BB BF (UTF-8 BOM): strip the three bytes and decode the REMAINDER.
+ *   If the remainder still contains U+FFFD (invalid UTF-8 somewhere in the
+ *   file), decode the remainder as Windows-1252. The BOM bytes are never
+ *   re-included, so the fallback can no longer produce a literal mojibake
+ *   "ï»¿" prefix that breaks exact-match header detection.
+ * - No BOM: try UTF-8; fall back to Windows-1252 on replacement characters
+ *   or garbled Swedish chars (unchanged behavior).
  */
 export function decodeFileContent(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer)
+
+  if (bytes.length >= 2 && bytes[0] === 0xff && bytes[1] === 0xfe) {
+    return new TextDecoder('utf-16le', { fatal: false }).decode(buffer)
+  }
+  if (bytes.length >= 2 && bytes[0] === 0xfe && bytes[1] === 0xff) {
+    return new TextDecoder('utf-16be', { fatal: false }).decode(buffer)
+  }
+
+  if (bytes.length >= 3 && bytes[0] === 0xef && bytes[1] === 0xbb && bytes[2] === 0xbf) {
+    const rest = bytes.subarray(3)
+    const utf8Rest = new TextDecoder('utf-8', { fatal: false }).decode(rest)
+    if (!utf8Rest.includes('�')) {
+      return utf8Rest
+    }
+    return new TextDecoder('windows-1252', { fatal: false }).decode(rest)
+  }
+
   const utf8Decoder = new TextDecoder('utf-8', { fatal: false })
   const utf8Result = utf8Decoder.decode(buffer)
 
@@ -72,11 +98,18 @@ export function normalizeLineEndings(content: string): string {
 }
 
 /**
- * Strip BOM (Byte Order Mark) from start of content
+ * Strip BOM (Byte Order Mark) from start of content.
+ *
+ * Also strips the literal mojibake form "ï»¿" (U+00EF U+00BB U+00BF): a
+ * UTF-8 BOM whose bytes were decoded as Windows-1252/Latin-1 upstream.
+ * Covers string-entry paths that were pre-decoded outside decodeFileContent.
  */
 export function stripBOM(content: string): string {
   if (content.charCodeAt(0) === 0xfeff) {
     return content.slice(1)
+  }
+  if (content.startsWith('ï»¿')) {
+    return content.slice(3)
   }
   return content
 }

--- a/skills/accounted-api/references/banking.md
+++ b/skills/accounted-api/references/banking.md
@@ -12,7 +12,7 @@ are in SKILL.md and are not repeated per endpoint.
 **Import a bank-file (CSV / XML / CAMT053).**
 `scope:transactions:write · risk:medium · idempotent`
 
-Accepts a bank statement file (UTF-8 / Windows-1252, up to 10 MB) as multipart/form-data. Auto-detects the bank format (SEB, Swedbank, Handelsbanken, Nordea, Nordea Business, Lansforsakringar, Lunar, ICA Banken, Skandia, Wise transaction history, Wise balance statement, CAMT053, generic CSV) or honors a `format` override. Parses transactions, ingests them into the `transactions` table (NOT into journal entries: see BFL note in pitfalls), and emits `transaction.synced` events. Returns operation_id for polling.
+Accepts a bank statement file (UTF-8 / UTF-16 / Windows-1252, up to 10 MB) as multipart/form-data. Auto-detects the bank format (SEB, Swedbank, Handelsbanken, Nordea, Nordea Business, Lansforsakringar, Lunar, ICA Banken, Skandia, Wise transaction history, Wise balance statement, CAMT053, generic CSV) or honors a `format` override. Parses transactions, ingests them into the `transactions` table (NOT into journal entries: see BFL note in pitfalls), and emits `transaction.synced` events. Returns operation_id for polling.
 
 **Use when:** Importing a bank statement export for a period. Common with PSD2 bank connections that don't auto-sync, or for legacy bank accounts.
 **Do not use for:** SIE bookkeeping import (use /imports/sie). Auto-bank sync (use the enable-banking extension). Single-transaction creation (use POST /transactions/ingest with a 1-element array).


### PR DESCRIPTION
## Problem (user report, items 1+2)
A user's SEB CSV import failed with "Filen kunde läsas men inga transaktioner hittades" and was attributed to the UTF-8 BOM. Verified against code: the BOM itself was already stripped on the main path, but two real defects sat underneath:

1. **Explicit format choice could be worse than auto-detect.** `parseBankFile` with an explicit `formatId` skipped detection entirely; the SEB profile only understands the Kontoutdrag header family split on `;`. Any other SEB export surface (Transaktioner, comma-delimited, bare `Datum`) parsed 0 rows, and the dashboard swallowed the parser's real error and showed the generic string.
2. **A narrow, real BOM bug**: a BOM'd file containing one invalid UTF-8 byte fell back to whole-file windows-1252 decode; the BOM became a literal mojibake prefix which the exact-match detectors (`h === 'datum'`) then tripped over.

## Fix
- `decodeFileContent` now handles BOMs at the byte level (utf-8-sig semantics; BOM bytes never re-included in the windows-1252 fallback) and decodes UTF-16LE/BE BOMs. `stripBOM` also strips the literal mojibake prefix.
- `parseBankFile`: when an explicit format parses 0 transactions, fall back to auto-detect; if another profile parses the file, return its result with an info issue naming both formats. `generic_csv` is exempt (it is the manual column-mapping escape hatch). External ids come from the winning format, so dedup is identical to the auto path (also on the v1 route).
- SEB profile: delimiter sniffing (`;` vs `,`), rows split with `parseCSVLine`, and a lowest-priority bare-`Datum` tier in parse only (never in detect).
- Dashboard shows the parser's real issues when 0 transactions parse; the touched parsers' user-facing issue strings are now Swedish.
- v1 route reuses `decodeFileContent` (one decode implementation).

## Tests
389 tests green across `lib/import` and both routes; every new test mutation-checked (BOM regressions, fallback engage/not-override, delimiter sniff, v1 provenance). `check:guards` passes.

## Flags
- The real SEB "Transaktioner" layout is still unverified (no fixture exists anywhere); the generic fallback deliberately does not depend on knowing it. Worth asking the reporter for the first two lines of their file.
- The new info-severity issue is not yet rendered in the preview step UI (only warning/error render there); surfacing it is a small follow-up needing visual sign-off.

---
Part of the 2026-08-13 user-feedback batch (Johan Lind, Celxius AB) plus one internally reported UI bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Bank-file imports now support UTF-8, UTF-16, and Windows-1252 encoded files, including files with byte-order marks.
  - Improved format detection automatically handles files that differ from the selected format.
  - SEB imports now support comma- and semicolon-delimited files, plus additional header layouts.

- **Bug Fixes**
  - Import errors now show specific parser issues and row numbers when available.
  - Improved handling prevents garbled text and provides clearer Swedish validation messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->