### PR TITLE
fix(settings): land Medlemmar clicks on the members section

### DIFF
--- a/components/dashboard/UserMenu.tsx
+++ b/components/dashboard/UserMenu.tsx
@@ -334,7 +334,7 @@ export default function UserMenu({
                 <Settings className="h-4 w-4 flex-shrink-0" />
                 {tNav('settings')}
               </Link>
-              <Link href="/settings/team" onClick={close} className={menuRow}>
+              <Link href="/settings/company#members" onClick={close} className={menuRow}>
                 <Users className="h-4 w-4 flex-shrink-0" />
                 {tNav('members_roles')}
               </Link>

--- a/components/settings/sections/CompanySettingsContent.tsx
+++ b/components/settings/sections/CompanySettingsContent.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useCallback } from 'react'
 import { useRouter } from 'next/navigation'
 import { useTranslations } from 'next-intl'
 import { CompanyDangerZone } from '@/components/settings/CompanyDangerZone'
@@ -21,6 +22,17 @@ export function CompanySettingsContent() {
   const tNav = useTranslations('settings_nav')
   const tIntro = useTranslations('settings_intro')
   const { settings, isLoading, updateSettings, refetch } = useSettings()
+
+  // Deep-link target for "Medlemmar och roller" (/settings/company#members):
+  // a ref callback rather than an effect because this content mounts late
+  // (settings fetch + dynamic import); the callback fires exactly when the
+  // section exists. The hash is cleared after scrolling so switching tabs
+  // and returning to Företag doesn't scroll again.
+  const scrollToMembers = useCallback((node: HTMLDivElement | null) => {
+    if (!node || window.location.hash !== '#members') return
+    node.scrollIntoView({ block: 'start' })
+    history.replaceState(null, '', window.location.pathname + window.location.search)
+  }, [])
 
   if (isLoading) return <SettingsLoadingSkeleton />
   if (!settings) return <SettingsLoadError onRetry={refetch} />
@@ -77,7 +89,9 @@ export function CompanySettingsContent() {
         onUpdate={(url) => updateSettings({ logo_url: url })}
       />
 
-      <CompanyMembersSection />
+      <div id="members" ref={scrollToMembers} className="scroll-mt-6">
+        <CompanyMembersSection />
+      </div>
 
       <FiscalPeriodEditor />
 


### PR DESCRIPTION
## What

Founder report: clicking "Medlemmar" (user menu → Medlemmar och roller) lands on the **Företag** settings page, where you have to scroll to find Medlemmar.

## Root cause

The link pointed at `/settings/team` — but in-app soft navigation is intercepted by the settings **modal**, whose `SETTINGS_SECTIONS` map has no `team` entry, and unknown sections deliberately fall back to `company`. (On a hard load, the same link would instead show the byrå TeamPanel — a different surface. The link's behavior depended on how you arrived.)

## Fix (the "scroll there immediately" option)

- User-menu link → `/settings/company#members`
- `CompanySettingsContent` scrolls the members section into view via a ref callback on the section wrapper — a callback rather than an effect because the content mounts late (settings fetch + dynamic import), so it fires exactly when the section exists, in both the modal and the full-page route
- Hash cleared after scrolling, so switching tabs and returning to Företag doesn't scroll again

Not touched: the `/settings/team` full-page route (consultant-team roster) still exists for whatever links to it externally; it just no longer backs the user-menu entry.

Lint clean, tsc clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)