### PR TITLE
test(bookkeeping): use hotel account in VAT fixture

### DIFF
--- a/lib/bookkeeping/__tests__/template-library.test.ts
+++ b/lib/bookkeeping/__tests__/template-library.test.ts
@@ -225,9 +225,9 @@ describe('deriveTemplateLinesFromBooking', () => {
   })
 
   it('snaps a 12% VAT line to the reduced rate', () => {
-    // Hotel: 5820 net 1000, 2641 VAT 120, 1930 gross 1120.
+    // Hotel: 5830 net 1000, 2641 VAT 120, 1930 gross 1120.
     const lines = deriveTemplateLinesFromBooking([
-      { account_number: '5820', debit_amount: '1000', credit_amount: '' },
+      { account_number: '5830', debit_amount: '1000', credit_amount: '' },
       { account_number: '2641', debit_amount: '120', credit_amount: '' },
       { account_number: '1930', debit_amount: '', credit_amount: '1120' },
     ])


### PR DESCRIPTION
## Summary

- update the remaining hotel VAT inference fixture from car-hire account `5820` to hotel account `5830`
- keep the fixture aligned with the production template correction merged in #1397
- confirm the reported wrong-account regression assertion still existed separately from the primary #1397 test

Relates to #1408.

## Validation

- `npx vitest run --project unit lib/bookkeeping/__tests__/template-library.test.ts`: 33 passed
- timeout-affected full-suite files rerun without concurrent lint load: 35 passed
- `npm run lint`: 0 errors, 270 existing warnings
- `npm test`: 14,180 passed; eight resource-contention timeouts passed on focused rerun; the unchanged `scripts/checks/__tests__/format-currency-sek-label.test.ts` Vitest parser anomaly remains reproducible on `main`

No production database operation is part of this PR.
