### PR TITLE
fix(transactions): move the bulk-match attn line below the inbox list

### DIFF
--- a/app/(dashboard)/transactions/page.tsx
+++ b/app/(dashboard)/transactions/page.tsx
@@ -3315,26 +3315,6 @@ export default function TransactionsPage() {
           )
         ) : (
           <div>
-            {/* Bridge to the bulk-match flow: a backlog of unbooked bank rows
-                is usually a migration/import whose counterpart vouchers
-                already exist, and the only match affordance here is per-row.
-                Static text + count (no probe): the reconciliation preview is
-                the honest source of how many actually match.
-                Yields to the review-suggestions attn at the top of the page
-                (max one ochre sentence per page): when the sweep has already
-                persisted suggestions, "Granska förslagen" is the more precise
-                destination for the same backlog. */}
-            {selectableInboxIds.length >= 5 && suggestionItems.length === 0 && (
-              <AttnLine
-                className="px-1 pb-3"
-                action={{
-                  label: t('recon_attn_action'),
-                  href: '/reports/bank-reconciliation?autorun=1',
-                }}
-              >
-                {t('recon_attn', { count: selectableInboxIds.length })}
-              </AttnLine>
-            )}
             {/* Bulkbar (concept): hidden until at least one transaction is
                 selected via the hover checkboxes, then it pops in with the
                 count and the batch actions. */}
@@ -3474,6 +3454,27 @@ export default function TransactionsPage() {
                 </tbody>
               </table>
             </div>
+            {/* Bridge to the bulk-match flow: a backlog of unbooked bank rows
+                is usually a migration/import whose counterpart vouchers
+                already exist, and the only match affordance here is per-row.
+                Static text + count (no probe): the reconciliation preview is
+                the honest source of how many actually match. Sits below the
+                list so the rows themselves stay first, and yields to the
+                review-suggestions attn at the top of the page (max one ochre
+                sentence per page): when the sweep has already persisted
+                suggestions, "Granska förslagen" is the more precise
+                destination for the same backlog. */}
+            {selectableInboxIds.length >= 5 && suggestionItems.length === 0 && (
+              <AttnLine
+                className="px-1 pt-3"
+                action={{
+                  label: t('recon_attn_action'),
+                  href: '/reports/bank-reconciliation?autorun=1',
+                }}
+              >
+                {t('recon_attn', { count: selectableInboxIds.length })}
+              </AttnLine>
+            )}
           </div>
         )
       ) : (


### PR DESCRIPTION
The recon-bridge CTA from #1571 ("N obokförda banktransaktioner: bankavstämningen kan hitta automatiska träffar ... Förhandsgranska träffar") rendered above the inbox rows, so the first thing on the list was a promo-shaped sentence instead of the transactions themselves.

Founder feedback: move it to the bottom or remove it. This keeps the bridge (discoverability of the bulk-match flow was the point of #1571) but renders it after the table, just above the footer status line. Same trigger (>=5 selectable bank rows), same action and copy; only the position and padding direction (pb-3 -> pt-3) change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Moved the reconciliation reminder below the transaction table.
  * Updated spacing so transaction rows and bulk actions appear before the reminder.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->