### PR TITLE
fix(reconciliation): await the pre-existing matched/storno match-log writes

### DIFF
--- a/app/api/transactions/[id]/match-invoice/route.ts
+++ b/app/api/transactions/[id]/match-invoice/route.ts
@@ -365,7 +365,7 @@ export const POST = withRouteContext(
           txLog.warn('failed to clear journal_entry_id after storno', clearJeError)
         }
 
-        logMatchEvent(supabase, user.id, transactionId, 'storno_conflict_resolved', {
+        await logMatchEvent(supabase, user.id, transactionId, 'storno_conflict_resolved', {
           invoiceId: invoice_id,
           previousState: { journal_entry_id: transaction.journal_entry_id },
           newState: { journal_entry_id: null },
@@ -776,7 +776,7 @@ export const POST = withRouteContext(
       })
     }
 
-    logMatchEvent(supabase, user.id, transactionId, 'matched', {
+    await logMatchEvent(supabase, user.id, transactionId, 'matched', {
       invoiceId: invoice_id,
       matchConfidence: 1.0,
       matchMethod: 'manual_confirm',

--- a/app/api/transactions/[id]/match-supplier-invoice/route.ts
+++ b/app/api/transactions/[id]/match-supplier-invoice/route.ts
@@ -501,7 +501,7 @@ export const POST = withRouteContext(
     // it is already anchored, e.g. on the registration verifikat.
     await anchorSupplierInvoiceDocument(supabase, companyId, supplier_invoice_id)
 
-    logMatchEvent(supabase, user.id, transactionId, 'matched', {
+    await logMatchEvent(supabase, user.id, transactionId, 'matched', {
       supplierInvoiceId: supplier_invoice_id,
       matchConfidence: 1.0,
       matchMethod: 'manual_confirm',

--- a/app/api/v1/companies/[companyId]/transactions/[id]/match-invoice/route.ts
+++ b/app/api/v1/companies/[companyId]/transactions/[id]/match-invoice/route.ts
@@ -437,7 +437,7 @@ export const POST = withApiV1<{ params: Promise<{ companyId: string; id: string 
         if (clearErr) {
           txLog.warn('failed to clear journal_entry_id after storno', clearErr)
         }
-        logMatchEvent(ctx.supabase, ctx.userId, txId, 'storno_conflict_resolved', {
+        await logMatchEvent(ctx.supabase, ctx.userId, txId, 'storno_conflict_resolved', {
           invoiceId: invoice_id,
           previousState: { journal_entry_id: transaction.journal_entry_id },
           newState: { journal_entry_id: null },
@@ -808,7 +808,7 @@ export const POST = withApiV1<{ params: Promise<{ companyId: string; id: string 
       })
     }
 
-    logMatchEvent(ctx.supabase, ctx.userId, txId, 'matched', {
+    await logMatchEvent(ctx.supabase, ctx.userId, txId, 'matched', {
       invoiceId: invoice_id,
       matchConfidence: 1.0,
       matchMethod: 'manual_confirm',

--- a/app/api/v1/companies/[companyId]/transactions/[id]/match-supplier-invoice/route.ts
+++ b/app/api/v1/companies/[companyId]/transactions/[id]/match-supplier-invoice/route.ts
@@ -581,7 +581,7 @@ export const POST = withApiV1<{ params: Promise<{ companyId: string; id: string 
     // invoice. No-op when it is already anchored. Never throws.
     await anchorSupplierInvoiceDocument(ctx.supabase, ctx.companyId!, supplier_invoice_id)
 
-    logMatchEvent(ctx.supabase, ctx.userId, txId, 'matched', {
+    await logMatchEvent(ctx.supabase, ctx.userId, txId, 'matched', {
       supplierInvoiceId: supplier_invoice_id,
       matchConfidence: 1.0,
       matchMethod: 'manual_confirm',


### PR DESCRIPTION
## What

Awaits the six fire-and-forget logMatchEvent calls that predate the SIE-migrator branch in the four match routes (match-invoice and match-supplier-invoice, cookie and v1 variants).

## Why

Follow-up to #1598: this was the final Swedish-review finding on that PR, approved by Emil, but its commit landed on the feature branch minutes after the squash-merge and was stranded outside main. logMatchEvent never throws; on serverless an unawaited promise can be frozen when the response returns, silently dropping the behandlingshistorik row (BFNAR 2013:2 kap 8). This closes the gap and makes the 'every audit write is awaited' invariant from #1598 actually hold on main.

Cherry-pick of f97954b35 from worktree-bank-and-sie-match onto main.

## Migrations

None.

## Test coverage

No behavior change to test; the 89 existing tests across the six affected suites pass locally, ESLint 0 errors, check:guards green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of transaction and supplier-invoice matching.
  * Ensured matching and conflict-resolution audit events are saved before processing continues or results are returned.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->