### PR TITLE
fix: false popup-blocked toast on Visa dokument + scope SKV reconnect line to skattekonto source

### DIFF
--- a/app/(dashboard)/transactions/page.tsx
+++ b/app/(dashboard)/transactions/page.tsx
@@ -745,7 +745,11 @@ export default function TransactionsPage() {
   )
 
   const sourceItems = useMemo<ContextPickerItem[]>(() => {
-    const showSkvSource = skvRows.length > 0
+    // Keep the Skatteverket source pickable while reconnect is needed even
+    // though the rows fetch fails then (401 -> skvRows []): the reconnect
+    // attn line only renders under this source, so dropping the option would
+    // hide the reconnect path exactly when it applies.
+    const showSkvSource = skvRows.length > 0 || skvNeedsReconnect
     const items: ContextPickerItem[] = [
       {
         id: 'all',
@@ -771,7 +775,7 @@ export default function TransactionsPage() {
       items.push({ id: 'skatteverket', label: t('source_skatteverket_label') })
     }
     return items
-  }, [cashAccounts, hasUnassignedBankRows, skvRows.length, t, totalSourceBalance])
+  }, [cashAccounts, hasUnassignedBankRows, skvNeedsReconnect, skvRows.length, t, totalSourceBalance])
 
   // A narrowed filter can go stale (account disabled, skv rows drained,
   // "övriga" bucket emptied): fall back to everything rather than filtering

--- a/app/(dashboard)/transactions/page.tsx
+++ b/app/(dashboard)/transactions/page.tsx
@@ -3161,7 +3161,10 @@ export default function TransactionsPage() {
       <TransactionStatusBar onOpenCreateDialog={() => setIsDialogOpen(true)} />
 
 
-      {skvNeedsReconnect ? (
+      {skvNeedsReconnect && sourceFilter === 'skatteverket' ? (
+        // Only when the user is actually looking at skattekonto rows: as a
+        // permanent page-wide line it read as noise (feedback 2026-08-14).
+        // The skattekonto page keeps its own reconnect line.
         <AttnLine action={{ label: t('skv_reconnect_cta'), href: '/settings/tax' }}>
           {t('skv_reconnect_body')}
         </AttnLine>

--- a/components/bookkeeping/DocumentViewButton.tsx
+++ b/components/bookkeeping/DocumentViewButton.tsx
@@ -40,7 +40,14 @@ export function DocumentViewButton({ documentId, label = 'Visa dokument', classN
       return
     }
 
-    if (!window.open(`/api/documents/${documentId}/inline`, '_blank', 'noopener,noreferrer')) {
+    // window.open() returns null BY SPEC when 'noopener' is in the features
+    // string, even on success, so passing it here made this toast fire on
+    // every successful open. Open with a real return value and sever the
+    // reverse channel manually (same pattern as lib/browser/deferred-tab.ts).
+    const tab = window.open(`/api/documents/${documentId}/inline`, '_blank')
+    if (tab) {
+      tab.opener = null
+    } else {
       toast({
         title: 'Kunde inte öppna dokumentet',
         description: 'Tillåt popupfönster för Accounted i webbläsaren och försök igen.',


### PR DESCRIPTION
Two small UX fixes from feedback 2026-08-14 (screenshot: Granskning slide-over).

## 1. "Kunde inte öppna dokumentet" fired even though the tab opened

`DocumentViewButton` called `window.open(url, '_blank', 'noopener,noreferrer')` and treated a null return as popup-blocked. But `window.open()` returns null **by spec** whenever `noopener` is in the features string — success included — so the destructive toast fired on every successful open. Now opens without the features string and severs the reverse channel manually (`tab.opener = null`), the same pattern `lib/browser/deferred-tab.ts` uses. The toast now appears only on a genuine block.

## 2. SKV reconnect line showed on /transactions permanently

The "Skattekontots transaktioner hämtas inte förrän du anslutit igen…" attn line rendered whenever the connection needed renewal, regardless of source filter — permanent noise. It now shows only when the source picker is on **Skatteverket** (the rows it actually explains). The skattekonto page keeps its own reconnect line, so the state is still discoverable there.

## Verification

- `eslint` on both files: 0 errors (3 pre-existing warnings untouched)
- `tsc --noEmit`: no errors in changed files
- No i18n changes (reuses existing keys), no migrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The Skatteverket reconnection message now appears only when viewing Skatteverket transactions, including when no transaction data is returned.
  * Improved document preview opening and popup detection, while preserving an error message when the preview cannot be opened.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->