### PR TITLE
feat(providers): release the WINT card in the migration wizard

### DIFF
--- a/components/extensions/general/ArcimMigrationWorkspace.tsx
+++ b/components/extensions/general/ArcimMigrationWorkspace.tsx
@@ -382,10 +382,10 @@ interface ConnectionStatus {
   }
 }
 
-// WINT shows as a disabled "Kommer snart" card until the integration is
-// verified against a live WINT account. Launch = remove it here AND set
-// WINT_MIGRATION_ENABLED=true (the server-side /connect gate).
-const COMING_SOON_PROVIDERS = new Set<ArcimProvider>(['wint'])
+// Providers listed here render as a disabled "Kommer snart" card. WINT was
+// the last entry: it is released now, so the set is empty. WINT still depends
+// on WINT_MIGRATION_ENABLED=true, the server-side /connect gate.
+const COMING_SOON_PROVIDERS = new Set<ArcimProvider>([])
 
 const PROVIDER_LOGOS: Record<ArcimProvider, string> = {
   fortnox: '/logos/fortnox.svg',


### PR DESCRIPTION
## What

Empties `COMING_SOON_PROVIDERS` so the WINT card in the migration wizard is selectable instead of rendering as a disabled "Kommer snart" chip.

## Why

The WINT provider (#1446) shipped dark: fully wired client and server, but hidden behind two gates. This removes the UI gate. The set itself stays so the next dark provider can use the same mechanism.

## Still gated

`WINT_MIGRATION_ENABLED=true` remains the server-side `/connect` gate and is unchanged by this PR. Without that env var set in the environment, the card is now clickable but the connection is rejected server-side, so the env var should be set in prod together with this merge.

## Risk

Low, UI-only, one constant. No migration, no money math, no ledger path. Rollback is unsetting `WINT_MIGRATION_ENABLED`.

## Verified

`npm run lint` (0 errors) and `npm run check:guards` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
