### PR TITLE
feat(import): the constellation breathes between beats

### DIFF
--- a/components/import/TheaterCanvas.tsx
+++ b/components/import/TheaterCanvas.tsx
@@ -215,12 +215,26 @@ const TheaterCanvas = forwardRef<TheaterCanvasHandle, {
       const ease = (v: number) => 1 - Math.pow(1 - v, 3)
       const byId = new Map(engine.nodes.map((n) => [n.id, n]))
 
+      // Ambient life (Living Paper): the constellation moves because it is
+      // alive right now, never to fake progress. Build mode gets full
+      // amplitude, settled reveals rest at half (the reveal is a verdict),
+      // reduced motion gets none (the loop is frozen anyway). Everything is
+      // derived from the clock inside this one rAF loop; no extra timers.
+      const ambient = reduced ? 0 : settled ? 0.5 : 1
+      // Every 7s a quiet luminance wave travels hub -> rim over 2.6s,
+      // brightening the hairline rings and edges it passes (alpha only, no
+      // color, no geometry). Build mode only; -1 means resting.
+      const ripple =
+        ambient === 1 && now % 7000 < 2600 ? ((now % 7000) / 2600) * 340 : -1
+      const rippleGlow = (radius: number, width: number) =>
+        ripple < 0 ? 0 : Math.max(0, 1 - Math.abs(radius - ripple) / width)
+
       for (const n of engine.nodes) {
         if (n.kind !== 'ring' || n.born == null) continue
         const p = ease(age(n))
         const rad = (n.ring ?? 0) * k
         ctx.strokeStyle = colors.hair
-        ctx.globalAlpha = 0.75 * p
+        ctx.globalAlpha = (0.75 + 0.18 * rippleGlow(n.ring ?? 0, 30)) * p
         ctx.lineWidth = 0.8
         ctx.beginPath()
         ctx.arc(cx, cy, rad, -Math.PI / 2, -Math.PI / 2 + Math.PI * 2 * p)
@@ -244,9 +258,11 @@ const TheaterCanvas = forwardRef<TheaterCanvasHandle, {
         const p = ease(Math.min(age(A), age(B)))
         const pa = pos(A)
         const pb = pos(B)
+        const glow =
+          ripple < 0 ? 0 : rippleGlow(Math.hypot((A.x + B.x) / 2, (A.y + B.y) / 2), 40)
         ctx.strokeStyle = colors.hair
         ctx.lineWidth = 0.8
-        ctx.globalAlpha = 0.65
+        ctx.globalAlpha = 0.65 + 0.12 * glow
         ctx.beginPath()
         ctx.moveTo(pa.x, pa.y)
         ctx.lineTo(pa.x + (pb.x - pa.x) * p, pa.y + (pb.y - pa.y) * p)
@@ -304,13 +320,20 @@ const TheaterCanvas = forwardRef<TheaterCanvasHandle, {
         if (n.born == null || n.kind === 'ring') continue
         const p = ease(age(n))
         const q = pos(n)
-        const breathe = reduced ? 0 : Math.sin(now / 2600 + n.x + n.y) * 0.06
+        // Per-node breathing on two slow, incommensurate clocks, offset by
+        // the node's own position/wave so the field shimmers organically
+        // instead of in sync. Radius +-10% (roughly 1px on the hub, less on
+        // small dots) and a few percent of alpha; half of both when settled.
+        const breathe = ambient * 0.1 * Math.sin(now / 2600 + n.x + n.y)
+        const twinkle = ambient * 0.04 * (0.5 + 0.5 * Math.sin(now / 3400 + n.x + n.wave * 1.7))
         const splat = p < 1 ? 1 + 0.3 * Math.sin(p * Math.PI) : 1
         const r = n.r * (1 + breathe) * p * k * 1.55 * splat
         ctx.fillStyle = n.kind === 'bucket' ? colors.mut : colors.ink
+        ctx.globalAlpha = 1 - twinkle
         ctx.beginPath()
         ctx.arc(q.x, q.y, r, 0, Math.PI * 2)
         ctx.fill()
+        ctx.globalAlpha = 1
         if (n.label && n.lab) {
           ctx.globalAlpha = Math.max(0, p * 1.2 - 0.2)
           ctx.fillStyle = n.kind === 'hub' ? colors.ink : colors.mut


### PR DESCRIPTION
## Why

Founder feedback after watching a real migration:

> "when the graph is being built, it should pulsate a little bit more, or some animation in the graph should happen even when there is nothing building to it. Otherwise, it gets stale quite quickly, and it should be kind of nice to look at. The user should feel like something is happening."

`TheaterCanvas` (shared by the /import theater, the Arcim migration theater, and the result reveals) only moved on spawn/feed/pulse events, so long holds like "Skriver till journalen..." looked frozen.

## What

Continuous ambient life, Living Paper style: motion means the system is alive right now, never that work completed. Everything is derived from the clock inside the existing single rAF loop; no new timers, no per-node state.

**Per-node breathing**
- Radius oscillates +-10% (roughly 1px on the hub dot, sub-pixel on small dots), alpha dips up to 4%, in build mode.
- Two slow incommensurate clocks (2.6s and 3.4s base periods), phase-offset by each node's own position and wave index, so the field shimmers organically rather than pulsing in sync.

**Quiet ripple**
- Every 7s a luminance wave travels hub to rim over 2.6s.
- It brightens the hairline year rings (stroke alpha 0.75 to 0.93 at the wave peak) and the edges it passes (0.65 to 0.77 at midpoint). The edge glow keeps the wave readable past the ring band, where the constellation extends well beyond the year rings.
- Alpha only: same hairline color, no geometry change. It cannot be confused with the sage `pulse()` ring, which stays reserved for real events.

**Mode behavior**
- Build mode and every waiting hold: full ambient (the loop is time-driven, so holds are covered automatically).
- Settled mode (result reveals): half breathing amplitude, no ripple. The reveal is a verdict; it may rest.
- `prefers-reduced-motion`: ambient scale is zero and the frame stays statically rendered exactly as before.

No color changes, no rotation, no bouncing. Amplitudes are ink-on-paper small by design.

## Gates

- `npx vitest run components lib/import`: 56 files, 981 tests, all green
- `tsc --noEmit`: zero new errors vs stash baseline
- `eslint components/import/TheaterCanvas.tsx`: 0 errors
- `package-lock.json` untouched

## Note

**VISUAL sign-off needed** before merge: this is motion tuning, the amplitudes and timings should be judged on a real migration run (/import theater plus a settled result reveal), including a reduced-motion check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ambient animation effects to the theater canvas, including periodic ripples, breathing nodes, and twinkling highlights.
  * Animation intensity is reduced in settled mode.

* **Accessibility**
  * Animations are automatically disabled when reduced-motion preferences are enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->