### PR TITLE
feat(vat): show already-booked banner when opening Momsdeklaration

### DIFF
--- a/components/reports/VatAlreadyBookedBanner.tsx
+++ b/components/reports/VatAlreadyBookedBanner.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import Link from 'next/link'
+import { Check } from 'lucide-react'
+import { formatDate } from '@/lib/utils'
+import { formatVoucher } from '@/lib/bookkeeping/voucher-series-resolver'
+import type { VatSettlementExistingEntry } from '@/lib/reports/vat-settlement'
+
+/**
+ * Status banner for Momsdeklaration: the period already has a posted
+ * momsomföring. Statutory surface, Swedish in both locales like the rest of
+ * the declaration. Read-only — does not claim the return was sent to SKV.
+ */
+export function VatAlreadyBookedBanner({
+  entry,
+}: {
+  entry: VatSettlementExistingEntry
+}) {
+  const voucher = formatVoucher(entry)
+  const voucherLabel = voucher === '-' ? 'verifikat' : `verifikat ${voucher}`
+
+  return (
+    <div
+      role="status"
+      className="mx-auto flex w-full max-w-3xl items-start gap-3 rounded-lg border border-success/30 bg-success/10 px-4 py-3 text-[13px] leading-6"
+    >
+      <Check className="mt-0.5 h-4 w-4 shrink-0 text-success" aria-hidden="true" />
+      <div className="min-w-0">
+        <p>
+          Momsen för perioden är redan bokförd:{' '}
+          <Link
+            href={`/bookkeeping/${entry.id}`}
+            className="font-medium underline underline-offset-2 hover:text-foreground"
+          >
+            {voucherLabel}
+          </Link>
+          {entry.entry_date ? ` (${formatDate(entry.entry_date)})` : ''}.
+        </p>
+        <p className="mt-1 text-muted-foreground">
+          Att öppna sidan räknar bara om rutorna från bokföringen. Du behöver
+          inte skapa ett nytt verifikat.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/components/reports/views/index.tsx
+++ b/components/reports/views/index.tsx
@@ -27,6 +27,7 @@ import { formatVoucher } from '@/lib/bookkeeping/voucher-series-resolver'
 import { AccountNumber } from '@/components/ui/account-number'
 import { ReportExportMenu } from '@/components/reports/ReportExportMenu'
 import { PageHeader } from '@/components/ui/page-header'
+import { VatAlreadyBookedBanner } from '@/components/reports/VatAlreadyBookedBanner'
 import { VatChecksCard } from '@/components/reports/VatChecksCard'
 import { runVatDeclarationChecks } from '@/lib/reports/vat-declaration-checks'
 import { rcInputTotalsFromDeclaration } from '@/lib/reports/vat-declaration'
@@ -42,7 +43,12 @@ import { SkatteverketPanel } from '@/components/reports/SkatteverketPanel'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { useCanWrite } from '@/lib/hooks/use-can-write'
 import type { FormLine } from '@/components/bookkeeping/JournalEntryForm'
-import type { VatSettlementProposal } from '@/lib/reports/vat-settlement'
+import {
+  findDraftVatSettlement,
+  findPostedVatSettlement,
+  vatSettlementBookingStatus,
+  type VatSettlementProposal,
+} from '@/lib/reports/vat-settlement'
 
 // Recharts is ~180KB: defer the chart components so report tables (the
 // regulated content) render without waiting for the charting bundle.
@@ -1124,74 +1130,32 @@ function VatManualFilingCard({ xmlHref, pdfHref }: { xmlHref: string; pdfHref: s
  * showing the declared figures after booking.
  */
 function VatBookingCard({
-  periodType,
-  year,
-  period,
-  fiscalPeriodId,
+  proposal,
+  failed,
+  loading,
+  onRetry,
+  onBooked,
   checksBlocked,
-  onStatus,
 }: {
-  periodType: VatPeriodType
-  year: number
-  period: number
-  fiscalPeriodId?: string
+  /** Settlement proposal from GET /settlement-proposal — fetched by the parent
+   *  so Granska can show the already-booked banner without waiting for step 3. */
+  proposal: VatSettlementProposal | null
+  failed: boolean
+  loading: boolean
+  onRetry: () => void
+  onBooked: () => void
   /**
    * True when the local pre-flight checks found ERRORs. Booking stays
    * possible (the RC-basis fixes only touch 44xx/45xx pairs, never the 26xx
    * accounts the settlement clears), but the user should know before filing.
    */
   checksBlocked?: boolean
-  /** Lets the surrounding stepper mirror the booking state on its dot. */
-  onStatus?: (status: 'booked' | 'draft' | 'none') => void
 }) {
   const { canWrite } = useCanWrite()
   const [dialogOpen, setDialogOpen] = useState(false)
-  const [refreshKey, setRefreshKey] = useState(0)
-  // Fetch outcome tagged with the key it was requested under; proposal/failed
-  // are derived by comparing that tag with the current key, so the effect
-  // never sets state synchronously (same pattern as VatDeclarationView).
-  const [result, setResult] = useState<{
-    key: string
-    proposal?: VatSettlementProposal
-    failed?: boolean
-  } | null>(null)
-  const fetchKey = `${periodType}:${year}:${period}:${fiscalPeriodId ?? ''}:${refreshKey}`
 
-  useEffect(() => {
-    const params = new URLSearchParams({
-      periodType,
-      year: String(year),
-      period: String(period),
-    })
-    if (fiscalPeriodId) params.set('fiscal_period_id', fiscalPeriodId)
-    let cancelled = false
-    fetch(`/api/reports/vat-declaration/settlement-proposal?${params.toString()}`)
-      .then(async (res) => {
-        const json = await res.json().catch(() => null)
-        if (cancelled) return
-        if (!res.ok || !json?.data) setResult({ key: fetchKey, failed: true })
-        else setResult({ key: fetchKey, proposal: json.data })
-      })
-      .catch(() => {
-        if (!cancelled) setResult({ key: fetchKey, failed: true })
-      })
-    return () => {
-      cancelled = true
-    }
-  }, [fetchKey, periodType, year, period, fiscalPeriodId])
-
-  const upToDate = result !== null && result.key === fetchKey
-  const proposal = upToDate ? (result.proposal ?? null) : null
-  const failed = upToDate && !!result.failed
-
-  const booked = proposal?.existing_entries.find((e) => e.status === 'posted')
-  const draft = booked ? undefined : proposal?.existing_entries.find((e) => e.status === 'draft')
-
-  const bookingStatus = booked ? 'booked' : draft ? 'draft' : 'none'
-  useEffect(() => {
-    if (upToDate && proposal) onStatus?.(bookingStatus)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [upToDate, bookingStatus])
+  const booked = findPostedVatSettlement(proposal?.existing_entries)
+  const draft = findDraftVatSettlement(proposal?.existing_entries)
 
   // FormLine amounts are input strings; the proposal's numbers are already
   // öre-rounded server-side, so this is display formatting, not money math.
@@ -1251,11 +1215,11 @@ function VatBookingCard({
         {failed ? (
           <div className="flex flex-wrap items-center gap-3">
             <p className="text-sm text-destructive">Kunde inte hämta verifikatförslaget.</p>
-            <Button variant="outline" onClick={() => setRefreshKey((k) => k + 1)}>
+            <Button variant="outline" onClick={onRetry}>
               Försök igen
             </Button>
           </div>
-        ) : !upToDate ? (
+        ) : loading ? (
           <Skeleton className="h-10 w-40" />
         ) : proposal?.is_empty ? (
           <p className="text-sm text-muted-foreground">Ingen moms att bokföra för perioden.</p>
@@ -1306,7 +1270,7 @@ function VatBookingCard({
                 initialLines={initialLines}
                 onCreated={() => {
                   setDialogOpen(false)
-                  setRefreshKey((k) => k + 1)
+                  onBooked()
                 }}
               />
             )}
@@ -1537,11 +1501,18 @@ export function VatDeclarationView({ pageTitle }: { pageTitle?: string } = {}) {
     error?: string
   } | null>(null)
   const [retryKey, setRetryKey] = useState(0)
+  const [settlementRetryKey, setSettlementRetryKey] = useState(0)
   // Stegen: which of the four pipeline steps is open. null = automatic
   // (errors land on Kontrollera, otherwise Granska). A period switch resets
   // to automatic so stale step choices never survive a context change.
   const [chosenStep, setChosenStep] = useState<number | null>(null)
-  const [bookingStatus, setBookingStatus] = useState<'booked' | 'draft' | 'none' | null>(null)
+  // Latest settlement-proposal fetch, tagged like the declaration result so
+  // Granska can show the already-booked banner on open (not only on step 3).
+  const [settlementResult, setSettlementResult] = useState<{
+    key: string
+    proposal?: VatSettlementProposal
+    failed?: boolean
+  } | null>(null)
   // Per-verifikat RC-basis scan, fetched here (not only inside VatChecksCard)
   // because the filing gate lives here and the worklist unmounts as soon as
   // the user leaves steg 1. Tagged with the PERIOD it was requested for (see
@@ -1645,7 +1616,6 @@ export function VatDeclarationView({ pageTitle }: { pageTitle?: string } = {}) {
 
   useEffect(() => {
     setChosenStep(null)
-    setBookingStatus(null)
   }, [periodType, year, period, fiscalPeriodId])
 
   useEffect(() => {
@@ -1678,6 +1648,45 @@ export function VatDeclarationView({ pageTitle }: { pageTitle?: string } = {}) {
       cancelled = true
     }
   }, [fetchKey, periodType, year, period, fiscalPeriodId])
+
+  const settlementFetchKey =
+    periodType === null || notVatRegistered || momsPeriodMissing || awaitingFiscalPeriod
+      ? null
+      : `${periodType}:${year}:${period}:${isYearly ? fiscalPeriodId : ''}:${settlementRetryKey}`
+
+  useEffect(() => {
+    if (!settlementFetchKey || periodType === null) return
+    const params = new URLSearchParams({
+      periodType,
+      year: String(year),
+      period: String(period),
+    })
+    if (periodType === 'yearly') params.set('fiscal_period_id', fiscalPeriodId)
+    let cancelled = false
+    fetch(`/api/reports/vat-declaration/settlement-proposal?${params.toString()}`)
+      .then(async (res) => {
+        const json = await res.json().catch(() => null)
+        if (cancelled) return
+        if (!res.ok || !json?.data) setSettlementResult({ key: settlementFetchKey, failed: true })
+        else setSettlementResult({ key: settlementFetchKey, proposal: json.data })
+      })
+      .catch(() => {
+        if (!cancelled) setSettlementResult({ key: settlementFetchKey, failed: true })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [settlementFetchKey, periodType, year, period, fiscalPeriodId])
+
+  const settlementUpToDate =
+    settlementResult !== null && settlementResult.key === settlementFetchKey
+  const settlementProposal = settlementUpToDate ? (settlementResult.proposal ?? null) : null
+  const settlementFailed = settlementUpToDate && !!settlementResult.failed
+  const postedSettlement = findPostedVatSettlement(settlementProposal?.existing_entries)
+  const bookingStatus =
+    settlementUpToDate && settlementProposal
+      ? vatSettlementBookingStatus(settlementProposal.existing_entries)
+      : null
 
   // The per-verifikat gap scan runs on the same key as the declaration, so a
   // korrigering (which bumps retryKey via onCorrected) re-verifies the gate
@@ -1995,6 +2004,8 @@ export function VatDeclarationView({ pageTitle }: { pageTitle?: string } = {}) {
             bookingStatus={bookingStatus}
           />
 
+          {postedSettlement && <VatAlreadyBookedBanner entry={postedSettlement} />}
+
           {activeStep === 1 && (
             <section className="mx-auto max-w-3xl space-y-3">
               <VatChecksCard
@@ -2213,12 +2224,12 @@ export function VatDeclarationView({ pageTitle }: { pageTitle?: string } = {}) {
           {activeStep === 3 && (
             <section className="mx-auto max-w-3xl space-y-3">
               <VatBookingCard
-              periodType={periodType}
-              year={year}
-              period={period}
-              fiscalPeriodId={isYearly ? fiscalPeriodId : undefined}
+              proposal={settlementProposal}
+              failed={settlementFailed}
+              loading={!settlementUpToDate}
+              onRetry={() => setSettlementRetryKey((k) => k + 1)}
+              onBooked={() => setSettlementRetryKey((k) => k + 1)}
               checksBlocked={checksBlocked}
-              onStatus={setBookingStatus}
             />
               <div className="flex justify-end">
                 <Button variant="outline" size="sm" onClick={() => setChosenStep(4)}>

--- a/lib/reports/__tests__/vat-settlement.test.ts
+++ b/lib/reports/__tests__/vat-settlement.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { buildVatSettlementProposal } from '../vat-settlement'
+import {
+  buildVatSettlementProposal,
+  findDraftVatSettlement,
+  findPostedVatSettlement,
+  vatSettlementBookingStatus,
+  type VatSettlementExistingEntry,
+} from '../vat-settlement'
 
 // ============================================================
 // Mock: fetchVatAccountTotals now goes through the
@@ -302,5 +308,54 @@ describe('buildVatSettlementProposal', () => {
     await expect(
       buildVatSettlementProposal(supabase, 'company-1', 'quarterly', 2026, 1),
     ).rejects.toThrow('existing vat_settlement lookup failed: boom')
+  })
+})
+
+describe('vat settlement booking status helpers', () => {
+  const posted: VatSettlementExistingEntry = {
+    id: 'je-posted',
+    status: 'posted',
+    entry_date: '2026-06-30',
+    source_type: 'vat_settlement',
+    voucher_series: 'A',
+    voucher_number: 83,
+  }
+  const draft: VatSettlementExistingEntry = {
+    id: 'je-draft',
+    status: 'draft',
+    entry_date: '2026-06-30',
+    source_type: 'vat_settlement',
+    voucher_series: 'A',
+    voucher_number: null,
+  }
+  const shaped: VatSettlementExistingEntry = {
+    id: 'je-shaped',
+    status: 'posted',
+    entry_date: '2026-03-31',
+    source_type: 'manual',
+    voucher_series: 'A',
+    voucher_number: 9,
+  }
+
+  it('picks the newest posted settlement, including shape-detected momsomföring', () => {
+    expect(findPostedVatSettlement([posted, shaped])).toEqual(posted)
+    expect(findPostedVatSettlement([shaped])).toEqual(shaped)
+    expect(findPostedVatSettlement([draft])).toBeUndefined()
+    expect(findPostedVatSettlement([])).toBeUndefined()
+    expect(findPostedVatSettlement(undefined)).toBeUndefined()
+  })
+
+  it('surfaces a draft only when nothing is posted', () => {
+    expect(findDraftVatSettlement([draft])).toEqual(draft)
+    expect(findDraftVatSettlement([posted, draft])).toBeUndefined()
+    expect(findDraftVatSettlement([])).toBeUndefined()
+  })
+
+  it('maps existing_entries to the stepper booking status', () => {
+    expect(vatSettlementBookingStatus([posted])).toBe('booked')
+    expect(vatSettlementBookingStatus([shaped])).toBe('booked')
+    expect(vatSettlementBookingStatus([draft])).toBe('draft')
+    expect(vatSettlementBookingStatus([])).toBe('none')
+    expect(vatSettlementBookingStatus(undefined)).toBe('none')
   })
 })

--- a/lib/reports/vat-settlement.ts
+++ b/lib/reports/vat-settlement.ts
@@ -64,6 +64,35 @@ export interface VatSettlementExistingEntry {
   voucher_number: number | null
 }
 
+export type VatSettlementBookingStatus = 'booked' | 'draft' | 'none'
+
+/**
+ * Latest posted settlement in the proposal's existing_entries list
+ * (tagged vat_settlement and/or shape-detected momsomföring). The list is
+ * already newest-first from buildVatSettlementProposal.
+ */
+export function findPostedVatSettlement(
+  entries: VatSettlementExistingEntry[] | null | undefined,
+): VatSettlementExistingEntry | undefined {
+  return entries?.find((e) => e.status === 'posted')
+}
+
+/** Unposted draft, but only when no posted settlement already gates the period. */
+export function findDraftVatSettlement(
+  entries: VatSettlementExistingEntry[] | null | undefined,
+): VatSettlementExistingEntry | undefined {
+  if (findPostedVatSettlement(entries)) return undefined
+  return entries?.find((e) => e.status === 'draft')
+}
+
+export function vatSettlementBookingStatus(
+  entries: VatSettlementExistingEntry[] | null | undefined,
+): VatSettlementBookingStatus {
+  if (findPostedVatSettlement(entries)) return 'booked'
+  if (entries?.some((e) => e.status === 'draft')) return 'draft'
+  return 'none'
+}
+
 export interface VatSettlementProposal {
   period: {
     type: VatPeriodType


### PR DESCRIPTION
## What and why

When a VAT period already has a posted settlement (`source_type` `vat_settlement` and/or the existing momsomföring shape-detect), Momsdeklaration only said so on step 3 (Bokför). Opening the page recalculates boxes and lands on Granska, so it looked like the period still needed booking.

This PR fetches the existing settlement-proposal lookup as soon as the period is known and shows a banner on open / Granska:

- **Momsen för perioden är redan bokförd:** link to the voucher (e.g. A83) with date
- **Att öppna sidan räknar bara om rutorna från bokföringen. Du behöver inte skapa ett nytt verifikat.**

Detection is unchanged and read-only (BFL): tagged settlements plus shape-detected momsomföring from `buildVatSettlementProposal`. Step 3 still disables **Skapa verifikat**. The banner does not claim the return was submitted to Skatteverket.

## Test plan

- [ ] Open Momsdeklaration for a period with a posted `vat_settlement` (or a manual momsomföring). Banner appears under the stepper on Granska without clicking Bokför.
- [ ] Voucher link opens the existing journal entry.
- [ ] Step 3 still shows the existing warning and **Skapa verifikat** stays disabled.
- [ ] Period with no settlement: no banner; create button still works.
- [ ] Draft-only settlement: no “already booked” banner; step 3 still mentions the draft.

## Checklist

- [x] Title follows Conventional Commits
- [x] `lib/reports/__tests__/vat-settlement.test.ts` covers the shared booking-status helpers; `npm run check:lint` is clean
- [x] UI copy is Swedish on the statutory moms surface (same as the rest of the declaration; not dual-locale i18n)
- [x] No migrations
- [x] No imports from `@/extensions/`
- [x] Commit is signed off (`git commit -s`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear VAT settlement status indicators for periods that are already booked or saved as drafts.
  * Existing bookkeeping entries now show their voucher reference and date when available.
  * Clarified that viewing an already booked VAT period recalculates values without creating a duplicate voucher.

* **Bug Fixes**
  * Improved detection and handling of posted, draft, and manually created VAT settlements.
  * Posted settlements now take precedence over drafts when determining the period status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->