### PR TITLE
fix(nav): replace the expired Discord invite in the user menu

### DIFF
--- a/components/dashboard/UserMenu.tsx
+++ b/components/dashboard/UserMenu.tsx
@@ -25,8 +25,9 @@ import {
 
 // Community invite (Accounted's Discord). Deliberately a constant, not
 // branding config: self-hosted rebrands can hide or swap it when someone
-// actually asks for that.
-const DISCORD_INVITE_URL = 'https://discord.gg/D9SxtTgvx'
+// actually asks for that. Must be a never-expiring invite: the previous one
+// expired and left logged-in users with a dead link.
+const DISCORD_INVITE_URL = 'https://discord.gg/nfE9Uyv69a'
 
 // Lucide ships no brand marks, so the Discord logo is inlined (simple-icons
 // path, CC0). Sized and colored like the surrounding lucide icons.


### PR DESCRIPTION
## Problem

A user reported that the Discord link in the app (user menu → "Discord-community") is dead, while the one on the website works:

> Har hittat till er Discord nu, länken som finns när man är inloggad i app.accounted.se har gått ut men den på hemsidan.

Verified against Discord's public invite API:

- Old `D9SxtTgvx` → `{"message": "Invite is expired.", "code": 50270}`
- New `nfE9Uyv69a` → guild **Accounted** (`1488081831440941076`), `expires_at: null`

## Change

One-line constant swap in `components/dashboard/UserMenu.tsx`, plus a note in the existing comment that this constant must hold a never-expiring invite so it does not silently rot again.

No i18n, migration, or logic changes: the label already exists in both `messages/sv.json` and `messages/en.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)