### PR TITLE
feat(agent): docked assistant sheet runs general.help on the single-call console

### DIFF
--- a/components/agent/AgentSheet.tsx
+++ b/components/agent/AgentSheet.tsx
@@ -18,6 +18,8 @@ import AgentChat, {
   normalizeStoredMessages,
   type ChatMessage,
 } from './AgentChat'
+import AskConsole, { type AskConsoleMessage } from './AskConsole'
+import { CHAT_INTENT_ID } from '@/lib/agent/ask/persist'
 import type { AgentPanelFloatRect, StoredStagedOperation } from '@/types'
 import {
   DOCK_GUTTER,
@@ -756,14 +758,35 @@ export default function AgentSheet({
           </button>
         </div>
       ) : loaded ? (
-        <AgentChat
-          key={loaded.id}
-          intentId={loaded.intentId}
-          contextRef={loaded.contextRef ?? undefined}
-          initialConversationId={loaded.id}
-          initialMessages={loaded.messages}
-          onConversationIdChange={(id) => setConversationId(id)}
-          onStatus={onStatus}
+        loaded.intentId === CHAT_INTENT_ID ? (
+          // Resumed free-form thread: the single-call console (runs on a local
+          // model). Its turns are text-only, so drop any empty/tool rows.
+          <AskConsole
+            key={loaded.id}
+            initialConversationId={loaded.id}
+            initialMessages={loaded.messages
+              .filter((m) => m.text.trim().length > 0)
+              .map((m): AskConsoleMessage => ({ role: m.role, text: m.text }))}
+            contextRef={loaded.contextRef}
+          />
+        ) : (
+          <AgentChat
+            key={loaded.id}
+            intentId={loaded.intentId}
+            contextRef={loaded.contextRef ?? undefined}
+            initialConversationId={loaded.id}
+            initialMessages={loaded.messages}
+            onConversationIdChange={(id) => setConversationId(id)}
+            onStatus={onStatus}
+          />
+        )
+      ) : intentId === CHAT_INTENT_ID ? (
+        // Fresh free-form ask (the FAB's "Fråga min assistent" catch-all).
+        <AskConsole
+          seedUserMessage={seedUserMessage}
+          initialConversationId={null}
+          contextRef={contextRef ?? null}
+          onConversationCreated={(id) => setConversationId(id)}
         />
       ) : (
         <AgentChat


### PR DESCRIPTION
## RIP-4 stage 1

The app-wide docked **"Fråga min assistent"** sheet rendered `general.help` through the streaming `AgentChat` runtime — so on a local/OpenAI-compatible model it **503'd**. It now renders **`AskConsole`** for `general.help` (both a fresh ask and a resumed thread): the same single-call, provider-agnostic path `/chat` already uses, with the read-only ledger tools + snapshot from #1767.

Every other intent (the write/staging flows, onboarding, kpi/settings/vat, etc.) still renders `AgentChat` unchanged, so **`run-turn.ts` is untouched** and stays until those migrate in later stages.

## Details

- Resumed free-form threads convert their stored `ChatMessage[]` to text-only (`AskConsoleMessage[]` — the console has no tool/staged rows).
- Fresh asks report the created conversation id back to the sheet via `onConversationCreated` (same role `onConversationIdChange` played).
- Same approved `AskConsole` design that's already live on `/chat`; here it just renders inside the docked sheet width.

## Scope / safety

Read-only surface only. No change to the write-flow intents, no change to `run-turn.ts` or `/api/agent/invoke`. lint + guards + 97 agent tests green; scoped typecheck clean.

## Follow-up (RIP-4 remaining)

Write-flow intents (categorization, invoice, supplier review, verifikat, bulk-book) → deterministic or single structured call; then onboarding; then delete `run-turn.ts`. Approach decision pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated free-form chat experience for conversations started from the chat intent.
  * Existing conversations now reopen with their prior non-empty messages preserved.
  * New conversations can be created directly from the chat experience while retaining the initial message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->