### PR TITLE
feat(peppol): receiving sits behind the access request, switch only once granted

### DIFF
--- a/app/api/settings/peppol/access/__tests__/route.test.ts
+++ b/app/api/settings/peppol/access/__tests__/route.test.ts
@@ -92,7 +92,7 @@ describe('POST /api/settings/peppol/access', () => {
     enqueue({ data: { company_name: 'Kund AB', org_number: '556677-8899' }, error: null }) // company settings
     service.enqueue({ data: requestedRow, error: null })                          // summary read
 
-    const response = await post({ note: 'Vi fakturerar Region Skåne' })
+    const response = await post({ note: 'Vi fakturerar Region Skåne', wants_receiving: true })
     const body = await response.json()
 
     expect(response.status).toBe(201)
@@ -101,8 +101,12 @@ describe('POST /api/settings/peppol/access', () => {
     const mail = sendEmailMock.mock.calls[0][0] as { to: string; subject: string; text: string }
     expect(mail.to).toBe('support@example.test')
     expect(mail.subject).toContain('Kund AB')
+    expect(mail.subject).toContain('mottagning')
     expect(mail.text).toContain('company-1')
     expect(mail.text).toContain('Region Skåne')
+    expect(mail.text).toContain('--receive')
+    const upsert = service.calls.find((c) => c.method === 'upsert')?.args[0] as Record<string, unknown>
+    expect(upsert.request_note).toBe('[vill ta emot e-fakturor] Vi fakturerar Region Skåne')
   })
 
   it('is idempotent for a repeated request (no second e-mail) and 409 when already enabled', async () => {

--- a/app/api/settings/peppol/access/route.ts
+++ b/app/api/settings/peppol/access/route.ts
@@ -18,7 +18,9 @@ import { getSupportRecipientEmail } from '@/lib/support'
 ensureInitialized()
 
 const RequestAccessSchema = z.object({
-  note: z.string().trim().max(2000).optional(),
+  note: z.string().trim().max(1800).optional(),
+  /** The company also wants to receive (one of the contracted tenant slots). */
+  wants_receiving: z.boolean().optional(),
 })
 
 function escapeHtml(value: string): string {
@@ -37,7 +39,13 @@ export const POST = withRouteContext(
   async (request, { supabase, companyId, user, log, requestId }) => {
     const validation = await validateBody(request, RequestAccessSchema)
     if (!validation.success) return validation.response
-    const note = validation.data.note?.trim() || null
+    const wantsReceiving = validation.data.wants_receiving === true
+    const userNote = validation.data.note?.trim() || null
+    // The receiving wish travels in the request note so the operators see it
+    // in `access.ts list` and in the mail, and grant it with --receive.
+    const note = [wantsReceiving ? '[vill ta emot e-fakturor]' : null, userNote]
+      .filter((part): part is string => !!part)
+      .join(' ') || null
 
     if (await isSandboxCompany(supabase, companyId)) {
       return privateNoStore(errorResponseFromCode('PEPPOL_SANDBOX_NOT_ALLOWED', log, { requestId }))
@@ -62,16 +70,16 @@ export const POST = withRouteContext(
           const orgNumber = (company as { org_number?: string | null } | null)?.org_number ?? 'saknas'
           const sent = await emailService.sendEmail({
             to: getSupportRecipientEmail(),
-            subject: `[${getBranding().appName.toLowerCase()} peppol] Åtkomstbegäran: ${companyName}`,
+            subject: `[${getBranding().appName.toLowerCase()} peppol] Åtkomstbegäran${wantsReceiving ? ' (+ mottagning)' : ''}: ${companyName}`,
             replyTo: user.email,
             html: [
               `<p><strong>Bolag:</strong> ${escapeHtml(companyName)} (${escapeHtml(orgNumber)})</p>`,
               `<p><strong>Company ID:</strong> ${companyId}</p>`,
               `<p><strong>Begärd av:</strong> ${escapeHtml(user.email ?? '')} (${user.id})</p>`,
               note ? `<hr /><p>${escapeHtml(note).replace(/\n/g, '<br />')}</p>` : '',
-              `<hr /><p>Aktivera: <code>npx tsx --env-file=.env.local scripts/peppol/access.ts enable ${companyId} --max-sends 50</code></p>`,
+              `<hr /><p>Aktivera: <code>npx tsx --env-file=.env.local scripts/peppol/access.ts enable ${companyId} --max-sends 50${wantsReceiving ? ' --receive' : ''}</code></p>`,
             ].join('\n'),
-            text: `Bolag: ${companyName} (${orgNumber})\nCompany ID: ${companyId}\nBegärd av: ${user.email ?? ''} (${user.id})\n\n${note ?? ''}\n\nAktivera: npx tsx --env-file=.env.local scripts/peppol/access.ts enable ${companyId} --max-sends 50`,
+            text: `Bolag: ${companyName} (${orgNumber})\nCompany ID: ${companyId}\nBegärd av: ${user.email ?? ''} (${user.id})\n\n${note ?? ''}\n\nAktivera: npx tsx --env-file=.env.local scripts/peppol/access.ts enable ${companyId} --max-sends 50${wantsReceiving ? ' --receive' : ''}`,
           })
           if (!sent.success) {
             log.warn('peppol access request e-mail failed', { companyId, reason: sent.error })

--- a/components/settings/PeppolReceiveSettings.tsx
+++ b/components/settings/PeppolReceiveSettings.tsx
@@ -55,6 +55,7 @@ export function PeppolReceiveSettings() {
   const [loadFailed, setLoadFailed] = useState(false)
   const [isSaving, setIsSaving] = useState(false)
   const [isRequesting, setIsRequesting] = useState(false)
+  const [wantsReceiving, setWantsReceiving] = useState(false)
 
   const load = useCallback(async () => {
     try {
@@ -86,7 +87,7 @@ export function PeppolReceiveSettings() {
       const response = await fetch('/api/settings/peppol/access', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({}),
+        body: JSON.stringify({ wants_receiving: wantsReceiving }),
       })
       const body = await response.json().catch(() => null) as {
         error?: { code?: string; message?: string; message_en?: string }
@@ -103,7 +104,7 @@ export function PeppolReceiveSettings() {
     } finally {
       setIsRequesting(false)
     }
-  }, [load, localeKey, t, toast])
+  }, [load, localeKey, t, toast, wantsReceiving])
 
   const toggleReceiving = useCallback(async (next: boolean) => {
     setIsSaving(true)
@@ -133,7 +134,7 @@ export function PeppolReceiveSettings() {
   const accessLine = (() => {
     if (!access) return null
     switch (access.status) {
-      case 'enabled': return t('access_enabled')
+      case 'enabled': return access.receive_enabled ? t('access_enabled_receiving') : t('access_enabled_send_only')
       case 'requested': return t('access_requested')
       case 'disabled': return t('access_disabled')
       default: return t('access_none')
@@ -166,7 +167,17 @@ export function PeppolReceiveSettings() {
           )}
         </div>
         {state !== null && transportAvailable && (access?.status === 'none' || access?.status === 'disabled') && (
-          <SettingsRowEnd>
+          <SettingsRowEnd className="flex-col items-end gap-2 md:flex-row md:items-center">
+            <label className="flex items-center gap-2 text-xs text-muted-foreground">
+              <input
+                type="checkbox"
+                className="h-4 w-4 rounded-sm border-border"
+                checked={wantsReceiving}
+                onChange={(event) => setWantsReceiving(event.target.checked)}
+                disabled={isRequesting || !canWrite}
+              />
+              {t('request_receiving_label')}
+            </label>
             <Button
               type="button"
               variant="outline"
@@ -179,26 +190,23 @@ export function PeppolReceiveSettings() {
         )}
       </SettingsRow>
 
-      <SettingsRow label={t('enable_label')} help={t('enable_help')}>
-        <SettingsRowEnd>
-          <Switch
-            checked={isOn}
-            onCheckedChange={(value) => void toggleReceiving(value)}
-            disabled={isSaving || !canWrite || !receivingAvailable || state === null}
-            aria-label={t('enable_label')}
-          />
-        </SettingsRowEnd>
-      </SettingsRow>
-      <SettingsRow label={t('status_label')} borderless>
-        <div className="min-w-0 space-y-1 text-sm">
-          {state === null || loadFailed ? (
-            <SettingsRowNote>{loadFailed ? t('load_failed') : t('loading')}</SettingsRowNote>
-          ) : !transportAvailable ? (
-            <SettingsRowNote>{t('provider_required')}</SettingsRowNote>
-          ) : !receivingAvailable && !isOn ? (
-            <SettingsRowNote>{t('receive_not_enabled')}</SettingsRowNote>
-          ) : (
-            <>
+      {/* Receiving is a separate grant (one contracted slot each): the switch
+          exists only once the operators granted it, or a registration already
+          exists that the company must be able to see and withdraw. */}
+      {(receivingAvailable || isOn) && (
+        <>
+          <SettingsRow label={t('enable_label')} help={t('enable_help')}>
+            <SettingsRowEnd>
+              <Switch
+                checked={isOn}
+                onCheckedChange={(value) => void toggleReceiving(value)}
+                disabled={isSaving || !canWrite || !receivingAvailable || state === null}
+                aria-label={t('enable_label')}
+              />
+            </SettingsRowEnd>
+          </SettingsRow>
+          <SettingsRow label={t('status_label')} borderless>
+            <div className="min-w-0 space-y-1 text-sm">
               <span>{registrationStatusLabel}</span>
               {registration && registration.status !== 'deregistered' && (
                 <SettingsRowNote className="block tabular-nums">
@@ -208,10 +216,10 @@ export function PeppolReceiveSettings() {
               {registration?.status === 'failed' && registration.last_error && (
                 <SettingsRowNote className="block">{registration.last_error}</SettingsRowNote>
               )}
-            </>
-          )}
-        </div>
-      </SettingsRow>
+            </div>
+          </SettingsRow>
+        </>
+      )}
     </SettingsGroup>
   )
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -2240,7 +2240,10 @@
     "request_failed_title": "Could not send the request",
     "sends_used": "{used} of {max} sends used",
     "sends_unlimited": "{used} sends, no limit",
-    "receive_not_enabled": "Receiving is enabled by us on request (limited number of slots)."
+    "receive_not_enabled": "Receiving is enabled by us on request (limited number of slots).",
+    "request_receiving_label": "We also want to receive e-invoices via Peppol (limited number of slots, enabled by us)",
+    "access_enabled_receiving": "Enabled for sending and receiving e-invoices.",
+    "access_enabled_send_only": "Enabled for sending e-invoices. Receiving is not included; write to support if you want to receive."
   },
   "settings_pdf_print": {
     "coming_soon": "Coming soon",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -2240,7 +2240,10 @@
     "request_failed_title": "Kunde inte skicka begäran",
     "sends_used": "{used} av {max} sändningar använda",
     "sends_unlimited": "{used} sändningar, ingen gräns",
-    "receive_not_enabled": "Mottagning aktiveras av oss på begäran (begränsat antal platser)."
+    "receive_not_enabled": "Mottagning aktiveras av oss på begäran (begränsat antal platser).",
+    "request_receiving_label": "Vi vill också ta emot e-fakturor via Peppol (begränsat antal platser, aktiveras av oss)",
+    "access_enabled_receiving": "Aktiverat för att skicka och ta emot e-fakturor.",
+    "access_enabled_send_only": "Aktiverat för att skicka e-fakturor. Mottagning ingår inte; skriv till support om ni vill ta emot."
   },
   "settings_pdf_print": {
     "coming_soon": "Kommer snart",


### PR DESCRIPTION
## Summary

Follow-up to #1794 after the founder looked at the settings page: the receiving switch and status row were visible (disabled) for every company, which read as if anyone could receive.

- The receiving switch + status row render only once the operators granted receiving (`receive_enabled`), or when a registration already exists that the company must be able to see and withdraw.
- The access request gets a checkbox "Vi vill också ta emot e-fakturor"; it lands in the request note (`[vill ta emot e-fakturor]`, visible in `access.ts list`) and in the support mail subject/command (`--receive`).
- The access line distinguishes send-only from send + receive.

No migrations. Tests: settings/peppol + access route suites (13 passed), eslint clean, guards pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TqFpxeWqbpR7bcwUJLRERQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to request Peppol receiving access alongside sending access.
  * Peppol status messages now distinguish between send-only and send-and-receive access.
  * Receiving options and status details appear when available or already enabled.
  * Access request notifications now identify receiving requests and include the appropriate activation command.

* **Improvements**
  * Limited access request notes to 1,800 characters.
  * Added English and Swedish translations for receiving access labels and statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->